### PR TITLE
Add dark theme toggle

### DIFF
--- a/arkiv_app/static/css/style.css
+++ b/arkiv_app/static/css/style.css
@@ -3,6 +3,13 @@
   --brand-color-dark: #1d7580;
   --text-color: #333;
   --bg-color: #fff;
+  --card-bg: #fff;
+}
+
+[data-theme="dark"] {
+  --text-color: #eee;
+  --bg-color: #121212;
+  --card-bg: #1e1e1e;
 }
 
 body {
@@ -22,6 +29,13 @@ nav {
   justify-content: space-between;
   align-items: center;
   padding: 1rem;
+  gap: 1rem;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
 }
 
 nav a {
@@ -45,7 +59,7 @@ a:hover {
 
 .container {
   width: 90%;
-  max-width: 800px;
+  max-width: 960px;
   margin: 2rem auto;
 }
 
@@ -89,12 +103,20 @@ button:hover {
   padding: 0.5rem 1rem;
 }
 
+.theme-toggle {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
 .btn:hover {
   background-color: var(--brand-color-dark);
 }
 
 .card {
-  background: #fff;
+  background: var(--card-bg);
   padding: 1.5rem;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);

--- a/arkiv_app/static/js/main.js
+++ b/arkiv_app/static/js/main.js
@@ -1,1 +1,19 @@
-// Placeholder for custom scripts
+function applyTheme(theme) {
+  document.documentElement.setAttribute('data-theme', theme);
+  localStorage.setItem('theme', theme);
+  const toggleBtn = document.querySelector('.theme-toggle');
+  if (toggleBtn) {
+    toggleBtn.textContent = theme === 'dark' ? '☀️' : '🌙';
+  }
+}
+
+function toggleTheme() {
+  const current = document.documentElement.getAttribute('data-theme');
+  const next = current === 'dark' ? 'light' : 'dark';
+  applyTheme(next);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const saved = localStorage.getItem('theme') || 'light';
+  applyTheme(saved);
+});

--- a/arkiv_app/templates/base.html
+++ b/arkiv_app/templates/base.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="light">
 <head>
   <meta charset="utf-8">
   <title>{% block title %}Arkiv{% endblock %}</title>
@@ -11,9 +11,12 @@
   <header>
     <nav class="container">
       <div class="brand"><a href="{{ url_for('main.index') }}">Arkiv</a></div>
-      {% if current_user.is_authenticated %}
-      <div><a href="{{ url_for('auth.logout') }}">Logout</a></div>
-      {% endif %}
+      <div class="actions">
+        <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">🌙</button>
+        {% if current_user.is_authenticated %}
+        <a href="{{ url_for('auth.logout') }}">Logout</a>
+        {% endif %}
+      </div>
     </nav>
   </header>
   <main class="container">


### PR DESCRIPTION
## Summary
- modernize base layout with theme toggle button
- implement dark theme variables
- persist and apply theme via JavaScript

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6841b72034c88332b1bab93dff05f06f