### PR TITLE
Implement Portuguese UI and flash improvements

### DIFF
--- a/arkiv_app/asset/forms.py
+++ b/arkiv_app/asset/forms.py
@@ -4,5 +4,5 @@ from wtforms import SubmitField
 
 
 class AssetUploadForm(FlaskForm):
-    file = FileField('File', validators=[FileRequired()])
-    submit = SubmitField('Upload')
+    file = FileField('Arquivo', validators=[FileRequired()])
+    submit = SubmitField('Enviar')

--- a/arkiv_app/asset/routes.py
+++ b/arkiv_app/asset/routes.py
@@ -37,7 +37,7 @@ def upload_asset(folder_id):
         quota = org.plan.storage_quota_gb * 1024 * 1024 * 1024
         if used + size > quota:
             os.remove(filepath)
-            flash('Storage quota exceeded')
+            flash('Limite de armazenamento excedido')
             return redirect(url_for('library.list_libraries'))
         asset = Asset(
             library_id=folder.library_id,
@@ -54,7 +54,7 @@ def upload_asset(folder_id):
         record_audit('create', 'asset', asset.id, user_id=current_user.id, org_id=org.id)
         generate_thumbnail.delay(asset.id, upload_path, thumb_path)
         perform_ocr.delay(asset.id)
-        flash('File uploaded')
+        flash('Arquivo enviado')
         return redirect(url_for('library.list_libraries'))
     assets = Asset.query.filter_by(folder_id=folder_id).all()
     return render_template('asset/list.html', form=form, assets=assets, folder=folder)

--- a/arkiv_app/auth/forms.py
+++ b/arkiv_app/auth/forms.py
@@ -5,5 +5,5 @@ from wtforms.validators import DataRequired, Email
 
 class LoginForm(FlaskForm):
     email = StringField('Email', validators=[DataRequired(), Email()])
-    password = PasswordField('Password', validators=[DataRequired()])
-    submit = SubmitField('Login')
+    password = PasswordField('Senha', validators=[DataRequired()])
+    submit = SubmitField('Entrar')

--- a/arkiv_app/auth/routes.py
+++ b/arkiv_app/auth/routes.py
@@ -21,7 +21,7 @@ def login():
         if user and user.check_password(form.password.data):
             login_user(user)
             return redirect(url_for('library.list_libraries'))
-        flash('Invalid credentials')
+        flash('Credenciais inválidas')
     return render_template('auth/login.html', form=form)
 
 

--- a/arkiv_app/folder/forms.py
+++ b/arkiv_app/folder/forms.py
@@ -4,7 +4,7 @@ from wtforms.validators import DataRequired
 
 
 class FolderForm(FlaskForm):
-    library_id = SelectField('Library', coerce=int, validators=[DataRequired()])
-    parent_id = SelectField('Parent', coerce=int, choices=[(0, 'Root')])
-    name = StringField('Name', validators=[DataRequired()])
-    submit = SubmitField('Save')
+    library_id = SelectField('Biblioteca', coerce=int, validators=[DataRequired()])
+    parent_id = SelectField('Pasta mãe', coerce=int, choices=[(0, 'Raiz')])
+    name = StringField('Nome', validators=[DataRequired()])
+    submit = SubmitField('Salvar')

--- a/arkiv_app/folder/routes.py
+++ b/arkiv_app/folder/routes.py
@@ -33,7 +33,7 @@ def create_folder():
         db.session.add(folder)
         db.session.commit()
         record_audit('create', 'folder', folder.id, user_id=current_user.id, org_id=current_user.memberships[0].org_id)
-        flash('Folder created')
+        flash('Pasta criada')
         return redirect(url_for('library.list_libraries'))
     return render_template('folder/form.html', form=form)
 
@@ -50,7 +50,7 @@ def edit_folder(folder_id):
         folder.name = form.name.data
         db.session.commit()
         record_audit('update', 'folder', folder.id, user_id=current_user.id, org_id=current_user.memberships[0].org_id)
-        flash('Folder updated')
+        flash('Pasta atualizada')
         return redirect(url_for('library.list_libraries'))
     return render_template('folder/form.html', form=form)
 
@@ -62,5 +62,5 @@ def delete_folder(folder_id):
     db.session.delete(folder)
     db.session.commit()
     record_audit('delete', 'folder', folder.id, user_id=current_user.id, org_id=current_user.memberships[0].org_id)
-    flash('Folder deleted')
+    flash('Pasta removida')
     return redirect(url_for('library.list_libraries'))

--- a/arkiv_app/library/forms.py
+++ b/arkiv_app/library/forms.py
@@ -4,6 +4,6 @@ from wtforms.validators import DataRequired
 
 
 class LibraryForm(FlaskForm):
-    name = StringField('Name', validators=[DataRequired()])
-    description = TextAreaField('Description')
-    submit = SubmitField('Save')
+    name = StringField('Nome', validators=[DataRequired()])
+    description = TextAreaField('Descrição')
+    submit = SubmitField('Salvar')

--- a/arkiv_app/library/routes.py
+++ b/arkiv_app/library/routes.py
@@ -25,7 +25,7 @@ def create_library():
         db.session.add(lib)
         db.session.commit()
         record_audit('create', 'library', lib.id, user_id=current_user.id, org_id=org_id)
-        flash('Library created')
+        flash('Biblioteca criada')
         return redirect(url_for('library.list_libraries'))
     return render_template('library/form.html', form=form)
 
@@ -40,7 +40,7 @@ def edit_library(lib_id):
         lib.description = form.description.data
         db.session.commit()
         record_audit('update', 'library', lib.id, user_id=current_user.id, org_id=current_user.memberships[0].org_id)
-        flash('Library updated')
+        flash('Biblioteca atualizada')
         return redirect(url_for('library.list_libraries'))
     return render_template('library/form.html', form=form)
 
@@ -52,5 +52,5 @@ def delete_library(lib_id):
     db.session.delete(lib)
     db.session.commit()
     record_audit('delete', 'library', lib.id, user_id=current_user.id, org_id=current_user.memberships[0].org_id)
-    flash('Library deleted')
+    flash('Biblioteca removida')
     return redirect(url_for('library.list_libraries'))

--- a/arkiv_app/static/css/style.css
+++ b/arkiv_app/static/css/style.css
@@ -132,6 +132,18 @@ button:hover {
   background: var(--brand-color);
   color: #fff;
   margin-bottom: 0.5rem;
-  padding: 0.5rem;
+  padding: 0.5rem 2rem 0.5rem 0.5rem;
   border-radius: 4px;
+  position: relative;
+}
+
+.flash-close {
+  position: absolute;
+  right: 0.5rem;
+  top: 0.25rem;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 1rem;
 }

--- a/arkiv_app/static/js/main.js
+++ b/arkiv_app/static/js/main.js
@@ -3,7 +3,7 @@ function applyTheme(theme) {
   localStorage.setItem('theme', theme);
   const toggleBtn = document.querySelector('.theme-toggle');
   if (toggleBtn) {
-    toggleBtn.textContent = theme === 'dark' ? '☀️' : '🌙';
+    toggleBtn.innerHTML = theme === 'dark' ? '<i class="bi bi-sun-fill"></i>' : '<i class="bi bi-moon-fill"></i>';
   }
 }
 
@@ -16,4 +16,8 @@ function toggleTheme() {
 document.addEventListener('DOMContentLoaded', () => {
   const saved = localStorage.getItem('theme') || 'light';
   applyTheme(saved);
+
+  document.querySelectorAll('.flash-item').forEach((el) => {
+    setTimeout(() => el.remove(), 5000);
+  });
 });

--- a/arkiv_app/tag/forms.py
+++ b/arkiv_app/tag/forms.py
@@ -4,6 +4,6 @@ from wtforms.validators import DataRequired
 
 
 class TagForm(FlaskForm):
-    name = StringField('Name', validators=[DataRequired()])
-    color_hex = StringField('Color')
-    submit = SubmitField('Save')
+    name = StringField('Nome', validators=[DataRequired()])
+    color_hex = StringField('Cor')
+    submit = SubmitField('Salvar')

--- a/arkiv_app/tag/routes.py
+++ b/arkiv_app/tag/routes.py
@@ -26,7 +26,7 @@ def create_tag():
         db.session.add(tag)
         db.session.commit()
         record_audit('create', 'tag', tag.id, user_id=current_user.id, org_id=org_id)
-        flash('Tag created')
+        flash('Tag criada')
         return redirect(url_for('tag.list_tags'))
     return render_template('tag/form.html', form=form)
 
@@ -41,7 +41,7 @@ def edit_tag(tag_id):
         tag.color_hex = form.color_hex.data
         db.session.commit()
         record_audit('update', 'tag', tag.id, user_id=current_user.id, org_id=current_user.memberships[0].org_id)
-        flash('Tag updated')
+        flash('Tag atualizada')
         return redirect(url_for('tag.list_tags'))
     return render_template('tag/form.html', form=form)
 
@@ -53,7 +53,7 @@ def delete_tag(tag_id):
     db.session.delete(tag)
     db.session.commit()
     record_audit('delete', 'tag', tag.id, user_id=current_user.id, org_id=current_user.memberships[0].org_id)
-    flash('Tag deleted')
+    flash('Tag removida')
     return redirect(url_for('tag.list_tags'))
 
 
@@ -64,5 +64,5 @@ def set_asset_tags(asset_id):
     tag_ids = request.form.getlist('tag_ids')
     asset.tags = Tag.query.filter(Tag.id.in_(tag_ids)).all()
     db.session.commit()
-    flash('Tags updated')
+    flash('Tags atualizadas')
     return redirect(request.referrer or url_for('asset.upload_asset', folder_id=asset.folder_id))

--- a/arkiv_app/templates/asset/list.html
+++ b/arkiv_app/templates/asset/list.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
-{% block title %}Assets{% endblock %}
+{% block title %}Arquivos{% endblock %}
 {% block content %}
-<h1>Assets for {{ folder.name }}</h1>
+<h1>Arquivos de {{ folder.name }}</h1>
 <form method="post" enctype="multipart/form-data" class="card">
   {{ form.hidden_tag() }}
   <div class="field">{{ form.file() }}</div>
@@ -11,7 +11,7 @@
   {% for asset in assets %}
   <li>{{ asset.filename_orig }} ({{ asset.size }} bytes)</li>
   {% else %}
-  <li>No assets</li>
+  <li>Nenhum arquivo</li>
   {% endfor %}
 </ul>
 {% endblock %}

--- a/arkiv_app/templates/auth/login.html
+++ b/arkiv_app/templates/auth/login.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
-{% block title %}Login{% endblock %}
+{% block title %}Entrar{% endblock %}
 {% block content %}
-<h1>Login</h1>
+<h1>Entrar</h1>
 <form method="post" class="card">
   {{ form.hidden_tag() }}
   <div class="field">

--- a/arkiv_app/templates/base.html
+++ b/arkiv_app/templates/base.html
@@ -1,10 +1,11 @@
 <!doctype html>
-<html lang="en" data-theme="light">
+<html lang="pt" data-theme="light">
 <head>
   <meta charset="utf-8">
   <title>{% block title %}Arkiv{% endblock %}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   {% block head %}{% endblock %}
 </head>
 <body>
@@ -12,9 +13,9 @@
     <nav class="container">
       <div class="brand"><a href="{{ url_for('main.index') }}">Arkiv</a></div>
       <div class="actions">
-        <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">🌙</button>
+        <button class="theme-toggle" onclick="toggleTheme()" aria-label="Alterar tema"><i class="bi bi-moon-fill"></i></button>
         {% if current_user.is_authenticated %}
-        <a href="{{ url_for('auth.logout') }}">Logout</a>
+        <a href="{{ url_for('auth.logout') }}">Sair</a>
         {% endif %}
       </div>
     </nav>
@@ -23,7 +24,9 @@
     {% with messages = get_flashed_messages() %}
       {% if messages %}
       <ul class="flash">
-        {% for m in messages %}<li>{{ m }}</li>{% endfor %}
+        {% for m in messages %}
+        <li class="flash-item">{{ m }} <button class="flash-close" aria-label="Fechar" onclick="this.parentElement.remove()">&times;</button></li>
+        {% endfor %}
       </ul>
       {% endif %}
     {% endwith %}

--- a/arkiv_app/templates/folder/form.html
+++ b/arkiv_app/templates/folder/form.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
-{% block title %}Folder{% endblock %}
+{% block title %}Pasta{% endblock %}
 {% block content %}
-<h1>Folder</h1>
+<h1>Pasta</h1>
 <form method="post" class="card">
   {{ form.hidden_tag() }}
   <div class="field">{{ form.library_id.label }} {{ form.library_id() }}</div>

--- a/arkiv_app/templates/index.html
+++ b/arkiv_app/templates/index.html
@@ -1,9 +1,9 @@
 {% extends 'base.html' %}
-{% block title %}Home{% endblock %}
+{% block title %}Início{% endblock %}
 {% block content %}
-<h1>Welcome to Arkiv</h1>
-<p>Manage your libraries and assets efficiently.</p>
+<h1>Bem-vindo ao Arkiv</h1>
+<p>Gerencie suas bibliotecas e arquivos de forma eficiente.</p>
 {% if not current_user.is_authenticated %}
-<a href="{{ url_for('auth.login') }}" class="btn">Login</a>
+<a href="{{ url_for('auth.login') }}" class="btn">Entrar</a>
 {% endif %}
 {% endblock %}

--- a/arkiv_app/templates/library/form.html
+++ b/arkiv_app/templates/library/form.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
-{% block title %}Library{% endblock %}
+{% block title %}Biblioteca{% endblock %}
 {% block content %}
-<h1>Library</h1>
+<h1>Biblioteca</h1>
 <form method="post" class="card">
   {{ form.hidden_tag() }}
   <div class="field">{{ form.name.label }} {{ form.name(size=32) }}</div>

--- a/arkiv_app/templates/library/list.html
+++ b/arkiv_app/templates/library/list.html
@@ -1,18 +1,18 @@
 {% extends 'base.html' %}
-{% block title %}Libraries{% endblock %}
+{% block title %}Bibliotecas{% endblock %}
 {% block content %}
-<h1>Libraries</h1>
-<a href="{{ url_for('library.create_library') }}" class="btn">New Library</a>
+<h1>Bibliotecas</h1>
+<a href="{{ url_for('library.create_library') }}" class="btn"><i class="bi bi-plus-circle"></i> Nova Biblioteca</a>
 <ul>
   {% for lib in libraries %}
   <li class="card" style="margin-bottom:1rem; list-style:none;">
-    {{ lib.name }} - <a href="{{ url_for('library.edit_library', lib_id=lib.id) }}">Edit</a>
+    {{ lib.name }} - <a href="{{ url_for('library.edit_library', lib_id=lib.id) }}"><i class="bi bi-pencil"></i> Editar</a>
     <form action="{{ url_for('library.delete_library', lib_id=lib.id) }}" method="post" style="display:inline">
-      <button type="submit" class="btn">Delete</button>
+      <button type="submit" class="btn"><i class="bi bi-trash"></i> Excluir</button>
     </form>
   </li>
   {% else %}
-  <li>No libraries</li>
+  <li>Nenhuma biblioteca</li>
   {% endfor %}
 </ul>
 {% endblock %}

--- a/arkiv_app/templates/search/results.html
+++ b/arkiv_app/templates/search/results.html
@@ -1,16 +1,16 @@
 {% extends 'base.html' %}
-{% block title %}Search{% endblock %}
+{% block title %}Busca{% endblock %}
 {% block content %}
-<h1>Results for "{{ query }}"</h1>
+<h1>Resultados para "{{ query }}"</h1>
 <ul>
   {% for a in assets %}
-  <li class="card">Asset: {{ a.filename_orig }}</li>
+  <li class="card">Arquivo: {{ a.filename_orig }}</li>
   {% endfor %}
   {% for f in folders %}
-  <li class="card">Folder: {{ f.name }}</li>
+  <li class="card">Pasta: {{ f.name }}</li>
   {% endfor %}
   {% for l in libraries %}
-  <li class="card">Library: {{ l.name }}</li>
+  <li class="card">Biblioteca: {{ l.name }}</li>
   {% endfor %}
 </ul>
 {% endblock %}

--- a/arkiv_app/templates/tag/list.html
+++ b/arkiv_app/templates/tag/list.html
@@ -2,17 +2,17 @@
 {% block title %}Tags{% endblock %}
 {% block content %}
 <h1>Tags</h1>
-<a href="{{ url_for('tag.create_tag') }}" class="btn">New Tag</a>
+<a href="{{ url_for('tag.create_tag') }}" class="btn"><i class="bi bi-plus-circle"></i> Nova Tag</a>
 <ul>
   {% for t in tags %}
   <li class="card" style="margin-bottom:1rem; list-style:none;">
-    {{ t.name }} - <a href="{{ url_for('tag.edit_tag', tag_id=t.id) }}">Edit</a>
+    {{ t.name }} - <a href="{{ url_for('tag.edit_tag', tag_id=t.id) }}"><i class="bi bi-pencil"></i> Editar</a>
     <form action="{{ url_for('tag.delete_tag', tag_id=t.id) }}" method="post" style="display:inline">
-      <button type="submit" class="btn">Delete</button>
+      <button type="submit" class="btn"><i class="bi bi-trash"></i> Excluir</button>
     </form>
   </li>
   {% else %}
-  <li>No tags</li>
+  <li>Nenhuma tag</li>
   {% endfor %}
 </ul>
 {% endblock %}

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -4,4 +4,4 @@ from flask_login import current_user
 def test_login_creates_session(client):
     res = client.post('/login', data={'email': 'test@example.com', 'password': 'test'}, follow_redirects=True)
     assert res.status_code == 200
-    assert b'Library' in res.data or b'Library' in res.data
+    assert b'Biblioteca' in res.data or b'Bibliotecas' in res.data


### PR DESCRIPTION
## Summary
- translate interface text to Portuguese
- add Bootstrap icons and update theme toggle
- make flash messages closable and auto-dismiss
- update tests for Portuguese output

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6841bb0668808332b80aa7e0ff9f5920