### PR TITLE
Create admin dashboard and default users

### DIFF
--- a/arkiv_app/__init__.py
+++ b/arkiv_app/__init__.py
@@ -54,9 +54,11 @@ def create_app(config_name='development'):
         resp.headers['Referrer-Policy'] = 'no-referrer-when-downgrade'
         return resp
 
-    # Só criar tabelas se estiver em desenvolvimento
-    if config_name == 'development':
+    # Só criar tabelas e dados iniciais em desenvolvimento/produção
+    if config_name != 'testing':
         with app.app_context():
             db.create_all()
+            from .utils.create_initial_data import ensure_initial_data
+            ensure_initial_data()
 
     return app

--- a/arkiv_app/admin/routes.py
+++ b/arkiv_app/admin/routes.py
@@ -1,17 +1,46 @@
-from flask import render_template
-from flask_login import login_required
+from flask import render_template, abort
+from flask_login import login_required, current_user
 
-from ..models import Organization, Plan
+from ..models import Organization, Plan, User, AuditLog
 from . import admin_bp
+
+def _staff_required():
+    if not current_user.is_authenticated or not current_user.is_staff:
+        abort(403)
 
 @admin_bp.route('/plans')
 @login_required
 def list_plans():
+    _staff_required()
     plans = Plan.query.all()
     return render_template('admin/plans.html', plans=plans)
 
 @admin_bp.route('/orgs')
 @login_required
 def list_orgs():
+    _staff_required()
     orgs = Organization.query.all()
     return render_template('admin/orgs.html', orgs=orgs)
+
+
+@admin_bp.route('/users')
+@login_required
+def list_users():
+    _staff_required()
+    users = User.query.all()
+    return render_template('admin/users.html', users=users)
+
+
+@admin_bp.route('/logs')
+@login_required
+def list_logs():
+    _staff_required()
+    logs = AuditLog.query.order_by(AuditLog.timestamp.desc()).limit(100).all()
+    return render_template('admin/logs.html', logs=logs)
+
+
+@admin_bp.route('/')
+@login_required
+def index():
+    _staff_required()
+    return render_template('admin/index.html')

--- a/arkiv_app/models.py
+++ b/arkiv_app/models.py
@@ -51,6 +51,7 @@ class User(db.Model):
     email = db.Column(db.String(150), unique=True, nullable=False, index=True)
     password_hash = db.Column(db.String(255), nullable=False)
     is_active = db.Column(db.Boolean, default=True)
+    is_staff = db.Column(db.Boolean, default=False)
     last_login = db.Column(db.DateTime)
     mfa_enabled = db.Column(db.Boolean, default=False)
 

--- a/arkiv_app/templates/admin/index.html
+++ b/arkiv_app/templates/admin/index.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block title %}Admin{% endblock %}
+{% block content %}
+<h1>Painel Administrativo</h1>
+<nav class="card" style="display:flex;gap:1rem;flex-wrap:wrap;">
+  <a href="{{ url_for('admin.list_users') }}" class="btn">Usuários</a>
+  <a href="{{ url_for('admin.list_orgs') }}" class="btn">Organizações</a>
+  <a href="{{ url_for('admin.list_plans') }}" class="btn">Planos</a>
+  <a href="{{ url_for('admin.list_logs') }}" class="btn">Auditoria</a>
+</nav>
+{% endblock %}

--- a/arkiv_app/templates/admin/logs.html
+++ b/arkiv_app/templates/admin/logs.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% block title %}Auditoria{% endblock %}
+{% block content %}
+<h1>Últimos Logs</h1>
+<table class="card" style="width:100%">
+  <tr><th>Org</th><th>Usuário</th><th>Ação</th><th>Entidade</th><th>ID</th><th>Data</th></tr>
+  {% for l in logs %}
+  <tr>
+    <td>{{ l.org_id }}</td>
+    <td>{{ l.user_id }}</td>
+    <td>{{ l.action }}</td>
+    <td>{{ l.entity }}</td>
+    <td>{{ l.entity_id }}</td>
+    <td>{{ l.timestamp.strftime('%Y-%m-%d %H:%M') }}</td>
+  </tr>
+  {% else %}
+  <tr><td colspan="6">Nenhum log</td></tr>
+  {% endfor %}
+</table>
+{% endblock %}

--- a/arkiv_app/templates/admin/orgs.html
+++ b/arkiv_app/templates/admin/orgs.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block title %}Organizações{% endblock %}
+{% block content %}
+<h1>Organizações</h1>
+<ul>
+  {% for org in orgs %}
+  <li class="card">{{ org.name }} ({{ org.slug }})</li>
+  {% else %}
+  <li>Nenhuma organização</li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/arkiv_app/templates/admin/plans.html
+++ b/arkiv_app/templates/admin/plans.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block title %}Planos{% endblock %}
+{% block content %}
+<h1>Planos</h1>
+<ul>
+  {% for plan in plans %}
+  <li class="card">{{ plan.name }} - {{ plan.storage_quota_gb }}GB</li>
+  {% else %}
+  <li>Nenhum plano</li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/arkiv_app/templates/admin/users.html
+++ b/arkiv_app/templates/admin/users.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+{% block title %}Usuários{% endblock %}
+{% block content %}
+<h1>Usuários</h1>
+<table class="card" style="width:100%">
+  <tr><th>Nome</th><th>Email</th><th>Ativo</th><th>Admin</th></tr>
+  {% for u in users %}
+  <tr>
+    <td>{{ u.name }}</td>
+    <td>{{ u.email }}</td>
+    <td>{{ 'Sim' if u.is_active else 'Não' }}</td>
+    <td>{{ 'Sim' if u.is_staff else 'Não' }}</td>
+  </tr>
+  {% else %}
+  <tr><td colspan="4">Nenhum usuário</td></tr>
+  {% endfor %}
+</table>
+{% endblock %}

--- a/arkiv_app/utils/create_initial_data.py
+++ b/arkiv_app/utils/create_initial_data.py
@@ -4,41 +4,58 @@ from arkiv_app.extensions import db
 from arkiv_app.models import Plan, Organization, User, Membership, Library
 
 
+def ensure_initial_data():
+    """Ensure demo data and admin user exist."""
+    # Criação do plano
+    plan = Plan.query.first()
+    if not plan:
+        plan = Plan(name='Basic', storage_quota_gb=10, price_monthly=0, features={})
+        db.session.add(plan)
+        db.session.commit()
+
+    # Criação da organização demo
+    org = Organization.query.filter_by(slug='democorp').first()
+    if not org:
+        org = Organization(name='DemoCorp', slug='democorp', plan_id=plan.id)
+        db.session.add(org)
+        db.session.commit()
+
+    # Criação do usuário owner demo
+    user = User.query.filter_by(email='owner@democorp.com').first()
+    if not user:
+        user = User(name='Owner', email='owner@democorp.com')
+        user.set_password('(OWNER)1234')  # Sempre hash da senha!
+        db.session.add(user)
+        db.session.commit()
+        membership = Membership(user_id=user.id, org_id=org.id, role='OWNER')
+        db.session.add(membership)
+        db.session.commit()
+
+    # Criação do usuário admin do sistema
+    admin_user = User.query.filter_by(email='admin@arkiv.com').first()
+    if not admin_user:
+        admin_user = User(name='Admin', email='admin@arkiv.com', is_staff=True)
+        admin_user.set_password('(ADMIN)1234')
+        db.session.add(admin_user)
+        db.session.commit()
+        admin_membership = Membership(user_id=admin_user.id, org_id=org.id, role='ADMIN')
+        db.session.add(admin_membership)
+        db.session.commit()
+
+    # Biblioteca default para a organização
+    lib = Library.query.filter_by(org_id=org.id, name='Default Library').first()
+    if not lib:
+        lib = Library(org_id=org.id, name='Default Library', description='Exemplo de biblioteca')
+        db.session.add(lib)
+        db.session.commit()
+
+    print('Initial data ensured.')
+
+
 def main():
     app = create_app()
     with app.app_context():
-        # Criação do plano
-        plan = Plan.query.first()
-        if not plan:
-            plan = Plan(name='Basic', storage_quota_gb=10, price_monthly=0, features={})
-            db.session.add(plan)
-            db.session.commit()
-
-        # Criação da organização demo
-        org = Organization.query.filter_by(slug='democorp').first()
-        if not org:
-            org = Organization(name='DemoCorp', slug='democorp', plan_id=plan.id)
-            db.session.add(org)
-            db.session.commit()
-
-        # Criação do usuário owner demo
-        user = User.query.filter_by(email='owner@democorp.com').first()
-        if not user:
-            user = User(name='Owner', email='owner@democorp.com')
-            user.set_password('(OWNER)1234')  # Sempre hash da senha!
-            db.session.add(user)
-            db.session.commit()
-            membership = Membership(user_id=user.id, org_id=org.id, role='OWNER')
-            db.session.add(membership)
-            db.session.commit()
-
-        # Biblioteca default para a organização
-        lib = Library.query.filter_by(org_id=org.id, name='Default Library').first()
-        if not lib:
-            lib = Library(org_id=org.id, name='Default Library', description='Exemplo de biblioteca')
-            db.session.add(lib)
-            db.session.commit()
-
+        ensure_initial_data()
         print('Initial data created.')
 
 


### PR DESCRIPTION
## Summary
- add `is_staff` field to `User`
- ensure default data with owner and admin users on startup
- add admin-only panel with user/org/plan/log listings
- provide simple admin templates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6841c0c0a14c83329f64c302a2f5f0ef