### PR TITLE
Improve auth setup

### DIFF
--- a/arkiv_app/__init__.py
+++ b/arkiv_app/__init__.py
@@ -1,6 +1,6 @@
 from flask import Flask
 from .config import config_by_name
-from .extensions import init_extensions, db
+from .extensions import init_extensions, db, csrf
 import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
 from flask_login import current_user
@@ -45,6 +45,7 @@ def create_app(config_name='development'):
     app.register_blueprint(search_bp)
     app.register_blueprint(reports_bp)
     app.register_blueprint(admin_bp)
+    csrf.exempt(api_bp)
 
     @app.after_request
     def _security_headers(resp):

--- a/arkiv_app/extensions.py
+++ b/arkiv_app/extensions.py
@@ -20,6 +20,7 @@ from pythonjsonlogger import jsonlogger
 import logging
 from flask_mail import Mail
 from flask_login import LoginManager
+from flask_wtf import CSRFProtect
 
 # Instances of extensions
 
@@ -28,8 +29,11 @@ migrate = Migrate()
 jwt = JWTManager()
 mail = Mail()
 login_manager = LoginManager()
+login_manager.login_view = "auth.login"
+login_manager.session_protection = "strong"
 limiter = Limiter(key_func=get_remote_address)
 metrics = None
+csrf = CSRFProtect()
 
 def init_extensions(app):
     db.init_app(app)
@@ -38,6 +42,7 @@ def init_extensions(app):
     mail.init_app(app)
     login_manager.init_app(app)
     limiter.init_app(app)
+    csrf.init_app(app)
     global metrics
     metrics = PrometheusMetrics(app)
     _setup_logging(app)

--- a/arkiv_app/models.py
+++ b/arkiv_app/models.py
@@ -21,6 +21,7 @@ except Exception:  # pragma: no cover - optional argon2 fallback
     ph = PasswordHasher()
 
 from .extensions import db
+from flask_login import UserMixin
 
 class Organization(db.Model):
     __tablename__ = 'organization'
@@ -44,7 +45,7 @@ class Plan(db.Model):
     features = db.Column(db.JSON)
 
 
-class User(db.Model):
+class User(db.Model, UserMixin):
     __tablename__ = 'user'
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(150), nullable=False)


### PR DESCRIPTION
## Summary
- integrate CSRF protection and configure login manager
- inherit from UserMixin to ensure Flask‑Login compatibility
- exempt API routes from CSRF

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6841c47507f483329ba6444fb447d45a