### PR TITLE
Fix library navigation and folder creation

### DIFF
--- a/arkiv_app/asset/routes.py
+++ b/arkiv_app/asset/routes.py
@@ -12,33 +12,36 @@ from .forms import AssetUploadForm
 from .tasks import generate_thumbnail, perform_ocr
 
 
-
-
-
-@asset_bp.route('/folders/<int:folder_id>/assets', methods=['GET', 'POST'])
+@asset_bp.route("/folders/<int:folder_id>/assets", methods=["GET", "POST"])
 @login_required
-@limiter.limit('20 per minute')
+@limiter.limit("20 per minute")
 def upload_asset(folder_id):
     folder = Folder.query.get_or_404(folder_id)
     form = AssetUploadForm()
     if form.validate_on_submit():
         file = form.file.data
         filename_storage = f"{uuid.uuid4().hex}_{file.filename}"
-        upload_path = current_app.config['UPLOAD_FOLDER']
-        thumb_path = current_app.config['THUMB_FOLDER']
+        upload_path = current_app.config["UPLOAD_FOLDER"]
+        thumb_path = current_app.config["THUMB_FOLDER"]
         os.makedirs(upload_path, exist_ok=True)
         os.makedirs(thumb_path, exist_ok=True)
         filepath = os.path.join(upload_path, filename_storage)
         file.save(filepath)
         size = os.path.getsize(filepath)
-        checksum = hashlib.sha256(open(filepath, 'rb').read()).hexdigest()
+        checksum = hashlib.sha256(open(filepath, "rb").read()).hexdigest()
         org = folder.library.organization
-        used = db.session.query(db.func.sum(Asset.size)).join(Library).filter(Library.org_id == org.id).scalar() or 0
+        used = (
+            db.session.query(db.func.sum(Asset.size))
+            .join(Library)
+            .filter(Library.org_id == org.id)
+            .scalar()
+            or 0
+        )
         quota = org.plan.storage_quota_gb * 1024 * 1024 * 1024
         if used + size > quota:
             os.remove(filepath)
-            flash('Limite de armazenamento excedido')
-            return redirect(url_for('library.list_libraries'))
+            flash("Limite de armazenamento excedido")
+            return redirect(url_for("asset.upload_asset", folder_id=folder.id))
         asset = Asset(
             library_id=folder.library_id,
             folder_id=folder.id,
@@ -51,10 +54,12 @@ def upload_asset(folder_id):
         )
         db.session.add(asset)
         db.session.commit()
-        record_audit('create', 'asset', asset.id, user_id=current_user.id, org_id=org.id)
+        record_audit(
+            "create", "asset", asset.id, user_id=current_user.id, org_id=org.id
+        )
         generate_thumbnail.delay(asset.id, upload_path, thumb_path)
         perform_ocr.delay(asset.id)
-        flash('Arquivo enviado')
-        return redirect(url_for('library.list_libraries'))
+        flash("Arquivo enviado")
+        return redirect(url_for("asset.upload_asset", folder_id=folder.id))
     assets = Asset.query.filter_by(folder_id=folder_id).all()
-    return render_template('asset/list.html', form=form, assets=assets, folder=folder)
+    return render_template("asset/list.html", form=form, assets=assets, folder=folder)

--- a/arkiv_app/folder/routes.py
+++ b/arkiv_app/folder/routes.py
@@ -1,4 +1,4 @@
-from flask import render_template, redirect, url_for, flash
+from flask import render_template, redirect, url_for, flash, request
 from flask_login import login_required, current_user
 
 from ..extensions import db
@@ -8,21 +8,31 @@ from . import folder_bp
 from .forms import FolderForm
 
 
-def _populate_form_choices(form):
-    org_id = current_user.memberships[0].org_id
-    libs = Library.query.filter_by(org_id=org_id).all()
+def _populate_form_choices(form, libs):
     form.library_id.choices = [(l.id, l.name) for l in libs]
-    # For parent folder, show only within selected library
-    form.parent_id.choices = [(0, 'Root')] + [
-        (f.id, f.name) for f in Folder.query.filter_by(library_id=form.library_id.data or libs[0].id).all()
-    ]
+    selected = form.library_id.data or (libs[0].id if libs else None)
+    if selected:
+        form.parent_id.choices = [(0, "Raiz")] + [
+            (f.id, f.name) for f in Folder.query.filter_by(library_id=selected).all()
+        ]
+    else:
+        form.parent_id.choices = [(0, "Raiz")]
 
 
-@folder_bp.route('/folders/create', methods=['GET', 'POST'])
+@folder_bp.route("/folders/create", methods=["GET", "POST"])
 @login_required
 def create_folder():
     form = FolderForm()
-    _populate_form_choices(form)
+    org_id = current_user.memberships[0].org_id
+    libs = Library.query.filter_by(org_id=org_id).all()
+    if not libs:
+        flash("Crie uma biblioteca antes de adicionar pastas")
+        return redirect(url_for("library.create_library"))
+    if request.args.get("library_id"):
+        form.library_id.data = int(request.args["library_id"])
+    if request.args.get("parent_id"):
+        form.parent_id.data = int(request.args["parent_id"])
+    _populate_form_choices(form, libs)
     if form.validate_on_submit():
         parent_id = form.parent_id.data or None
         folder = Folder(
@@ -32,35 +42,66 @@ def create_folder():
         )
         db.session.add(folder)
         db.session.commit()
-        record_audit('create', 'folder', folder.id, user_id=current_user.id, org_id=current_user.memberships[0].org_id)
-        flash('Pasta criada')
-        return redirect(url_for('library.list_libraries'))
-    return render_template('folder/form.html', form=form)
+        record_audit(
+            "create",
+            "folder",
+            folder.id,
+            user_id=current_user.id,
+            org_id=current_user.memberships[0].org_id,
+        )
+        flash("Pasta criada")
+        return redirect(url_for("library.list_libraries"))
+    return render_template("folder/form.html", form=form)
 
 
-@folder_bp.route('/folders/<int:folder_id>/edit', methods=['GET', 'POST'])
+@folder_bp.route("/folders/<int:folder_id>/edit", methods=["GET", "POST"])
 @login_required
 def edit_folder(folder_id):
     folder = Folder.query.get_or_404(folder_id)
     form = FolderForm(obj=folder)
-    _populate_form_choices(form)
+    org_id = current_user.memberships[0].org_id
+    libs = Library.query.filter_by(org_id=org_id).all()
+    if not libs:
+        flash("Crie uma biblioteca antes de adicionar pastas")
+        return redirect(url_for("library.create_library"))
+    _populate_form_choices(form, libs)
     if form.validate_on_submit():
         folder.library_id = form.library_id.data
         folder.parent_id = form.parent_id.data or None
         folder.name = form.name.data
         db.session.commit()
-        record_audit('update', 'folder', folder.id, user_id=current_user.id, org_id=current_user.memberships[0].org_id)
-        flash('Pasta atualizada')
-        return redirect(url_for('library.list_libraries'))
-    return render_template('folder/form.html', form=form)
+        record_audit(
+            "update",
+            "folder",
+            folder.id,
+            user_id=current_user.id,
+            org_id=current_user.memberships[0].org_id,
+        )
+        flash("Pasta atualizada")
+        return redirect(url_for("library.list_libraries"))
+    return render_template("folder/form.html", form=form)
 
 
-@folder_bp.route('/folders/<int:folder_id>/delete', methods=['POST'])
+@folder_bp.route("/folders/<int:folder_id>/delete", methods=["POST"])
 @login_required
 def delete_folder(folder_id):
     folder = Folder.query.get_or_404(folder_id)
     db.session.delete(folder)
     db.session.commit()
-    record_audit('delete', 'folder', folder.id, user_id=current_user.id, org_id=current_user.memberships[0].org_id)
-    flash('Pasta removida')
-    return redirect(url_for('library.list_libraries'))
+    record_audit(
+        "delete",
+        "folder",
+        folder.id,
+        user_id=current_user.id,
+        org_id=current_user.memberships[0].org_id,
+    )
+    flash("Pasta removida")
+    return redirect(url_for("library.list_libraries"))
+
+
+@folder_bp.route("/folders/<int:folder_id>")
+@login_required
+def view_folder(folder_id):
+    folder = Folder.query.get_or_404(folder_id)
+    subfolders = Folder.query.filter_by(parent_id=folder.id).all()
+    return render_template("folder/detail.html", folder=folder, subfolders=subfolders)

--- a/arkiv_app/library/routes.py
+++ b/arkiv_app/library/routes.py
@@ -3,34 +3,46 @@ from flask_login import login_required, current_user
 
 from ..extensions import db
 from ..utils.audit import record_audit
-from ..models import Library
+from ..models import Library, Folder
 from . import library_bp
 from .forms import LibraryForm
 
 
-@library_bp.route('/libraries')
+@library_bp.route("/libraries")
 @login_required
 def list_libraries():
     libs = Library.query.filter_by(org_id=current_user.memberships[0].org_id).all()
-    return render_template('library/list.html', libraries=libs)
+    return render_template("library/list.html", libraries=libs)
 
 
-@library_bp.route('/libraries/create', methods=['GET', 'POST'])
+@library_bp.route("/libraries/<int:lib_id>")
+@login_required
+def show_library(lib_id):
+    lib = Library.query.get_or_404(lib_id)
+    folders = Folder.query.filter_by(library_id=lib_id, parent_id=None).all()
+    return render_template("library/detail.html", library=lib, folders=folders)
+
+
+@library_bp.route("/libraries/create", methods=["GET", "POST"])
 @login_required
 def create_library():
     form = LibraryForm()
     if form.validate_on_submit():
         org_id = current_user.memberships[0].org_id
-        lib = Library(org_id=org_id, name=form.name.data, description=form.description.data)
+        lib = Library(
+            org_id=org_id, name=form.name.data, description=form.description.data
+        )
         db.session.add(lib)
         db.session.commit()
-        record_audit('create', 'library', lib.id, user_id=current_user.id, org_id=org_id)
-        flash('Biblioteca criada')
-        return redirect(url_for('library.list_libraries'))
-    return render_template('library/form.html', form=form)
+        record_audit(
+            "create", "library", lib.id, user_id=current_user.id, org_id=org_id
+        )
+        flash("Biblioteca criada")
+        return redirect(url_for("library.list_libraries"))
+    return render_template("library/form.html", form=form)
 
 
-@library_bp.route('/libraries/<int:lib_id>/edit', methods=['GET', 'POST'])
+@library_bp.route("/libraries/<int:lib_id>/edit", methods=["GET", "POST"])
 @login_required
 def edit_library(lib_id):
     lib = Library.query.get_or_404(lib_id)
@@ -39,18 +51,30 @@ def edit_library(lib_id):
         lib.name = form.name.data
         lib.description = form.description.data
         db.session.commit()
-        record_audit('update', 'library', lib.id, user_id=current_user.id, org_id=current_user.memberships[0].org_id)
-        flash('Biblioteca atualizada')
-        return redirect(url_for('library.list_libraries'))
-    return render_template('library/form.html', form=form)
+        record_audit(
+            "update",
+            "library",
+            lib.id,
+            user_id=current_user.id,
+            org_id=current_user.memberships[0].org_id,
+        )
+        flash("Biblioteca atualizada")
+        return redirect(url_for("library.list_libraries"))
+    return render_template("library/form.html", form=form)
 
 
-@library_bp.route('/libraries/<int:lib_id>/delete', methods=['POST'])
+@library_bp.route("/libraries/<int:lib_id>/delete", methods=["POST"])
 @login_required
 def delete_library(lib_id):
     lib = Library.query.get_or_404(lib_id)
     db.session.delete(lib)
     db.session.commit()
-    record_audit('delete', 'library', lib.id, user_id=current_user.id, org_id=current_user.memberships[0].org_id)
-    flash('Biblioteca removida')
-    return redirect(url_for('library.list_libraries'))
+    record_audit(
+        "delete",
+        "library",
+        lib.id,
+        user_id=current_user.id,
+        org_id=current_user.memberships[0].org_id,
+    )
+    flash("Biblioteca removida")
+    return redirect(url_for("library.list_libraries"))

--- a/arkiv_app/templates/asset/list.html
+++ b/arkiv_app/templates/asset/list.html
@@ -2,6 +2,7 @@
 {% block title %}Arquivos{% endblock %}
 {% block content %}
 <h1>Arquivos de {{ folder.name }}</h1>
+<p><a href="{{ url_for('folder.view_folder', folder_id=folder.id) }}">Voltar para pasta</a></p>
 <form method="post" enctype="multipart/form-data" class="card">
   {{ form.hidden_tag() }}
   <div class="field">{{ form.file() }}</div>

--- a/arkiv_app/templates/folder/detail.html
+++ b/arkiv_app/templates/folder/detail.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block title %}{{ folder.name }}{% endblock %}
+{% block content %}
+<h1>{{ folder.name }}</h1>
+<p><a href="{{ url_for('library.show_library', lib_id=folder.library_id) }}">Voltar para biblioteca</a></p>
+<a href="{{ url_for('asset.upload_asset', folder_id=folder.id) }}" class="btn"><i class="bi bi-upload"></i> Enviar Arquivo</a>
+<a href="{{ url_for('folder.create_folder') }}?library_id={{ folder.library_id }}&parent_id={{ folder.id }}" class="btn"><i class="bi bi-folder-plus"></i> Nova Subpasta</a>
+<ul>
+  {% for sub in subfolders %}
+  <li><a href="{{ url_for('folder.view_folder', folder_id=sub.id) }}">{{ sub.name }}</a></li>
+  {% else %}
+  <li>Nenhuma subpasta</li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/arkiv_app/templates/index.html
+++ b/arkiv_app/templates/index.html
@@ -3,7 +3,9 @@
 {% block content %}
 <h1>Bem-vindo ao Arkiv</h1>
 <p>Gerencie suas bibliotecas e arquivos de forma eficiente.</p>
-{% if not current_user.is_authenticated %}
+{% if current_user.is_authenticated %}
+<a href="{{ url_for('library.list_libraries') }}" class="btn">Bibliotecas</a>
+{% else %}
 <a href="{{ url_for('auth.login') }}" class="btn">Entrar</a>
 {% endif %}
 {% endblock %}

--- a/arkiv_app/templates/library/detail.html
+++ b/arkiv_app/templates/library/detail.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block title %}{{ library.name }}{% endblock %}
+{% block content %}
+<h1>{{ library.name }}</h1>
+<p><a href="{{ url_for('library.list_libraries') }}">Voltar para lista</a></p>
+<p>{{ library.description }}</p>
+<a href="{{ url_for('folder.create_folder') }}?library_id={{ library.id }}" class="btn"><i class="bi bi-folder-plus"></i> Nova Pasta</a>
+<ul>
+  {% for folder in folders %}
+  <li><a href="{{ url_for('folder.view_folder', folder_id=folder.id) }}">{{ folder.name }}</a></li>
+  {% else %}
+  <li>Nenhuma pasta</li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/arkiv_app/templates/library/list.html
+++ b/arkiv_app/templates/library/list.html
@@ -6,7 +6,8 @@
 <ul>
   {% for lib in libraries %}
   <li class="card" style="margin-bottom:1rem; list-style:none;">
-    {{ lib.name }} - <a href="{{ url_for('library.edit_library', lib_id=lib.id) }}"><i class="bi bi-pencil"></i> Editar</a>
+    <a href="{{ url_for('library.show_library', lib_id=lib.id) }}">{{ lib.name }}</a> -
+    <a href="{{ url_for('library.edit_library', lib_id=lib.id) }}"><i class="bi bi-pencil"></i> Editar</a>
     <form action="{{ url_for('library.delete_library', lib_id=lib.id) }}" method="post" style="display:inline">
       <button type="submit" class="btn"><i class="bi bi-trash"></i> Excluir</button>
     </form>

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -1,0 +1,18 @@
+from arkiv_app.extensions import db
+from arkiv_app.models import Library
+
+
+def test_library_detail_view(client, app):
+    client.post(
+        "/login",
+        data={"email": "test@example.com", "password": "test"},
+        follow_redirects=True,
+    )
+    with app.app_context():
+        lib = Library(org_id=1, name="Demo", description="desc")
+        db.session.add(lib)
+        db.session.commit()
+        lib_id = lib.id
+    res = client.get(f"/libraries/{lib_id}")
+    assert res.status_code == 200
+    assert b"Demo" in res.data


### PR DESCRIPTION
## Summary
- add library details page and link from list
- add folder details page with upload and subfolder links
- handle no-library case when creating folders
- redirect asset uploads back to folder
- tweak index page navigation
- add basic test for library detail view

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6841c75abbe48332bb675094f3d28b0c