### PR TITLE
Fix plan relationship and safe org ID retrieval

### DIFF
--- a/arkiv_app/__init__.py
+++ b/arkiv_app/__init__.py
@@ -5,6 +5,8 @@ import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
 from flask_login import current_user
 
+from .utils import current_org_id
+
 def create_app(config_name='development'):
     app = Flask(__name__)
     app.config.from_object(config_by_name[config_name])
@@ -18,9 +20,10 @@ def create_app(config_name='development'):
             if current_user.is_authenticated:
                 with sentry_sdk.configure_scope() as scope:
                     scope.set_user({'id': current_user.id, 'email': current_user.email})
-                    # Aqui pode dar erro se memberships for vazio. Ajusta se necessário.
-                    org_id = current_user.memberships[0].org_id
-                    scope.set_tag('org_id', org_id)
+                    # set organization tag only if available
+                    org_id = current_org_id()
+                    if org_id is not None:
+                        scope.set_tag('org_id', org_id)
 
     init_extensions(app)
 

--- a/arkiv_app/folder/routes.py
+++ b/arkiv_app/folder/routes.py
@@ -1,6 +1,8 @@
 from flask import render_template, redirect, url_for, flash, request
 from flask_login import login_required, current_user
 
+from ..utils import current_org_id
+
 from ..extensions import db
 from ..models import Library, Folder
 from ..utils.audit import record_audit
@@ -23,7 +25,7 @@ def _populate_form_choices(form, libs):
 @login_required
 def create_folder():
     form = FolderForm()
-    org_id = current_user.memberships[0].org_id
+    org_id = current_org_id()
     libs = Library.query.filter_by(org_id=org_id).all()
     if not libs:
         flash("Crie uma biblioteca antes de adicionar pastas")
@@ -47,7 +49,7 @@ def create_folder():
             "folder",
             folder.id,
             user_id=current_user.id,
-            org_id=current_user.memberships[0].org_id,
+            org_id=org_id,
         )
         flash("Pasta criada")
         return redirect(url_for("library.list_libraries"))
@@ -59,7 +61,7 @@ def create_folder():
 def edit_folder(folder_id):
     folder = Folder.query.get_or_404(folder_id)
     form = FolderForm(obj=folder)
-    org_id = current_user.memberships[0].org_id
+    org_id = current_org_id()
     libs = Library.query.filter_by(org_id=org_id).all()
     if not libs:
         flash("Crie uma biblioteca antes de adicionar pastas")
@@ -75,7 +77,7 @@ def edit_folder(folder_id):
             "folder",
             folder.id,
             user_id=current_user.id,
-            org_id=current_user.memberships[0].org_id,
+            org_id=org_id,
         )
         flash("Pasta atualizada")
         return redirect(url_for("library.list_libraries"))
@@ -93,7 +95,7 @@ def delete_folder(folder_id):
         "folder",
         folder.id,
         user_id=current_user.id,
-        org_id=current_user.memberships[0].org_id,
+        org_id=current_org_id(),
     )
     flash("Pasta removida")
     return redirect(url_for("library.list_libraries"))

--- a/arkiv_app/library/routes.py
+++ b/arkiv_app/library/routes.py
@@ -1,6 +1,8 @@
 from flask import render_template, redirect, url_for, flash, request
 from flask_login import login_required, current_user
 
+from ..utils import current_org_id
+
 from ..extensions import db
 from ..utils.audit import record_audit
 from ..models import Library, Folder
@@ -11,7 +13,8 @@ from .forms import LibraryForm
 @library_bp.route("/libraries")
 @login_required
 def list_libraries():
-    libs = Library.query.filter_by(org_id=current_user.memberships[0].org_id).all()
+    org_id = current_org_id()
+    libs = Library.query.filter_by(org_id=org_id).all() if org_id else []
     return render_template("library/list.html", libraries=libs)
 
 
@@ -28,7 +31,7 @@ def show_library(lib_id):
 def create_library():
     form = LibraryForm()
     if form.validate_on_submit():
-        org_id = current_user.memberships[0].org_id
+        org_id = current_org_id()
         lib = Library(
             org_id=org_id, name=form.name.data, description=form.description.data
         )
@@ -56,7 +59,7 @@ def edit_library(lib_id):
             "library",
             lib.id,
             user_id=current_user.id,
-            org_id=current_user.memberships[0].org_id,
+            org_id=current_org_id(),
         )
         flash("Biblioteca atualizada")
         return redirect(url_for("library.list_libraries"))
@@ -74,7 +77,7 @@ def delete_library(lib_id):
         "library",
         lib.id,
         user_id=current_user.id,
-        org_id=current_user.memberships[0].org_id,
+        org_id=current_org_id(),
     )
     flash("Biblioteca removida")
     return redirect(url_for("library.list_libraries"))

--- a/arkiv_app/models.py
+++ b/arkiv_app/models.py
@@ -29,6 +29,7 @@ class Organization(db.Model):
     name = db.Column(db.String(150), unique=True, nullable=False)
     slug = db.Column(db.String(100), unique=True, nullable=False)
     plan_id = db.Column(db.Integer, db.ForeignKey('plan.id'), nullable=False)
+    plan = db.relationship('Plan', backref='organizations')
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     is_active = db.Column(db.Boolean, default=True)
 

--- a/arkiv_app/reports/routes.py
+++ b/arkiv_app/reports/routes.py
@@ -1,5 +1,7 @@
 from flask import Response
 from flask_login import login_required, current_user
+
+from ..utils import current_org_id
 import csv
 from io import StringIO, BytesIO
 import pandas as pd
@@ -11,7 +13,7 @@ from . import reports_bp
 @reports_bp.route('/reports/assets.csv')
 @login_required
 def assets_report():
-    org_id = current_user.memberships[0].org_id
+    org_id = current_org_id()
     assets = (
         Asset.query
         .join(Library)
@@ -33,7 +35,7 @@ def assets_report():
 @reports_bp.route('/reports/assets.xlsx')
 @login_required
 def assets_report_xlsx():
-    org_id = current_user.memberships[0].org_id
+    org_id = current_org_id()
     assets = (
         Asset.query
         .join(Library)

--- a/arkiv_app/search/routes.py
+++ b/arkiv_app/search/routes.py
@@ -1,6 +1,8 @@
 from flask import render_template, request, jsonify
 from flask_login import login_required, current_user
 
+from ..utils import current_org_id
+
 from ..models import Asset, Library, Folder
 from . import search_bp
 
@@ -9,7 +11,7 @@ from . import search_bp
 @login_required
 def search_page():
     q = request.args.get('q', '')
-    org_id = current_user.memberships[0].org_id
+    org_id = current_org_id()
     assets = []
     folders = []
     libs = []
@@ -25,7 +27,7 @@ def search_page():
 @login_required
 def api_search():
     q = request.args.get('q', '')
-    org_id = current_user.memberships[0].org_id
+    org_id = current_org_id()
     results = []
     if q:
         like = f"%{q}%"

--- a/arkiv_app/tag/routes.py
+++ b/arkiv_app/tag/routes.py
@@ -4,6 +4,7 @@ from flask_login import login_required, current_user
 from ..extensions import db
 from ..models import Tag, Asset
 from ..utils.audit import record_audit
+from ..utils import current_org_id
 from . import tag_bp
 from .forms import TagForm
 
@@ -11,7 +12,7 @@ from .forms import TagForm
 @tag_bp.route('/tags')
 @login_required
 def list_tags():
-    org_id = current_user.memberships[0].org_id
+    org_id = current_org_id()
     tags = Tag.query.filter_by(org_id=org_id).all()
     return render_template('tag/list.html', tags=tags)
 
@@ -21,7 +22,7 @@ def list_tags():
 def create_tag():
     form = TagForm()
     if form.validate_on_submit():
-        org_id = current_user.memberships[0].org_id
+        org_id = current_org_id()
         tag = Tag(org_id=org_id, name=form.name.data, color_hex=form.color_hex.data or '#CCCCCC')
         db.session.add(tag)
         db.session.commit()
@@ -40,7 +41,7 @@ def edit_tag(tag_id):
         tag.name = form.name.data
         tag.color_hex = form.color_hex.data
         db.session.commit()
-        record_audit('update', 'tag', tag.id, user_id=current_user.id, org_id=current_user.memberships[0].org_id)
+        record_audit('update', 'tag', tag.id, user_id=current_user.id, org_id=current_org_id())
         flash('Tag atualizada')
         return redirect(url_for('tag.list_tags'))
     return render_template('tag/form.html', form=form)
@@ -52,7 +53,7 @@ def delete_tag(tag_id):
     tag = Tag.query.get_or_404(tag_id)
     db.session.delete(tag)
     db.session.commit()
-    record_audit('delete', 'tag', tag.id, user_id=current_user.id, org_id=current_user.memberships[0].org_id)
+    record_audit('delete', 'tag', tag.id, user_id=current_user.id, org_id=current_org_id())
     flash('Tag removida')
     return redirect(url_for('tag.list_tags'))
 

--- a/arkiv_app/utils/__init__.py
+++ b/arkiv_app/utils/__init__.py
@@ -1,0 +1,8 @@
+from flask_login import current_user
+
+
+def current_org_id():
+    """Return the org_id of the current user's first membership, if any."""
+    if current_user.is_authenticated and current_user.memberships:
+        return current_user.memberships[0].org_id
+    return None


### PR DESCRIPTION
## Summary
- add missing `plan` relationship on `Organization` model
- add utility `current_org_id()` to safely retrieve user's organization
- handle absence of membership throughout routes
- avoid crashing Sentry integration when org is missing

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6841d10dd01c83328cdcc1608e11157c