### PR TITLE
Fix AuditLog autoincrement

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ class AssetTag(db.Model):
 
 class AuditLog(db.Model):
     __tablename__ = "audit_log"
-    id = db.Column(db.BigInteger, primary_key=True)
+    id = db.Column(db.BigInteger, primary_key=True, autoincrement=True)
     org_id = db.Column(db.Integer, db.ForeignKey("organization.id"), nullable=False)
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
     action = db.Column(db.String(50), nullable=False)       # ex.: "CREATE_ASSET", "DELETE_TAG"

--- a/arkiv_app/models.py
+++ b/arkiv_app/models.py
@@ -155,7 +155,7 @@ class AssetTag(db.Model):
 
 class AuditLog(db.Model):
     __tablename__ = 'audit_log'
-    id = db.Column(db.BigInteger, primary_key=True)
+    id = db.Column(db.BigInteger, primary_key=True, autoincrement=True)
     org_id = db.Column(db.Integer, db.ForeignKey('organization.id'), nullable=False)
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     action = db.Column(db.String(50), nullable=False)


### PR DESCRIPTION
## Summary
- ensure `AuditLog.id` auto increments in the models
- document autoincrement behavior in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6842417987b48332adcada051ca75bc2