### PR TITLE
Fix tests by disabling CSRF protection

### DIFF
--- a/arkiv_app/config.py
+++ b/arkiv_app/config.py
@@ -26,6 +26,7 @@ class ProductionConfig(Config):
 class TestConfig(Config):
     TESTING = True
     SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
+    WTF_CSRF_ENABLED = False
 
 config_by_name = {
     'development': DevelopmentConfig,


### PR DESCRIPTION
## Summary
- disable CSRF protection in the testing config so form posts work in tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68424473a05483328db1d4dff27f5f1d