### PR TITLE
Fix AuditLog schema for SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ class AssetTag(db.Model):
 
 class AuditLog(db.Model):
     __tablename__ = "audit_log"
-    id = db.Column(db.BigInteger, primary_key=True, autoincrement=True)
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     org_id = db.Column(db.Integer, db.ForeignKey("organization.id"), nullable=False)
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
     action = db.Column(db.String(50), nullable=False)       # ex.: "CREATE_ASSET", "DELETE_TAG"
@@ -529,6 +529,7 @@ class AuditLog(db.Model):
 
     __table_args__ = (
         db.Index("idx_audit_org_time", "org_id", "timestamp"),
+        {"sqlite_autoincrement": True},
     )
 ```
 
@@ -613,6 +614,7 @@ class AuditLog(db.Model):
    * Cada CRUD importante dispara gravação em `AuditLog`.
    * Armazenamos: `org_id`, `user_id`, `action`, `entity`, `entity_id`, `timestamp`, `ip_address` e `payload` (dados antes e depois).
    * Particionamento mensal para performance (via `pg_partman` ou particionamento nativo do PostgreSQL 16).
+   * Para bancos SQLite legados sem `AUTOINCREMENT` nessa tabela, execute `ensure_audit_log_schema()` ou recrie `audit_log` manualmente.
 
 3. **Métricas & Monitoramento**
 
@@ -826,6 +828,8 @@ Se o app mobile será feito em **MAUI**, convém expor APIs RESTful no backend p
    flask db upgrade
    python -m arkiv_app.utils.create_initial_data
    ```
+
+   * Caso utilize SQLite legado, execute também `ensure_audit_log_schema()` para corrigir a tabela `audit_log`.
 
    * Cria organização “DemoCorp” e usuário `owner@democorp.com` / `(OWNER)1234`.
 

--- a/arkiv_app/__init__.py
+++ b/arkiv_app/__init__.py
@@ -6,6 +6,7 @@ from sentry_sdk.integrations.flask import FlaskIntegration
 from flask_login import current_user
 
 from .utils import current_org_id
+from .utils.audit import ensure_audit_log_schema
 
 def create_app(config_name='development'):
     app = Flask(__name__)
@@ -62,7 +63,11 @@ def create_app(config_name='development'):
     if config_name != 'testing':
         with app.app_context():
             db.create_all()
+            ensure_audit_log_schema()
             from .utils.create_initial_data import ensure_initial_data
             ensure_initial_data()
+    else:
+        with app.app_context():
+            ensure_audit_log_schema()
 
     return app

--- a/arkiv_app/models.py
+++ b/arkiv_app/models.py
@@ -155,7 +155,7 @@ class AssetTag(db.Model):
 
 class AuditLog(db.Model):
     __tablename__ = 'audit_log'
-    id = db.Column(db.BigInteger, primary_key=True, autoincrement=True)
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     org_id = db.Column(db.Integer, db.ForeignKey('organization.id'), nullable=False)
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     action = db.Column(db.String(50), nullable=False)
@@ -167,4 +167,7 @@ class AuditLog(db.Model):
 
     __table_args__ = (
         db.Index('idx_audit_org_time', 'org_id', 'timestamp'),
+        {
+            'sqlite_autoincrement': True,
+        },
     )

--- a/arkiv_app/utils/audit.py
+++ b/arkiv_app/utils/audit.py
@@ -1,4 +1,5 @@
 from flask import request
+from sqlalchemy import text
 from ..extensions import db
 from ..models import AuditLog
 
@@ -15,3 +16,26 @@ def record_audit(action, entity, entity_id, user_id=None, org_id=None, payload=N
     )
     db.session.add(log)
     db.session.commit()
+
+
+def ensure_audit_log_schema():
+    """Ensure audit_log uses AUTOINCREMENT on SQLite."""
+    engine = db.engine
+    if not engine.url.drivername.startswith("sqlite"):
+        return
+    result = engine.execute(
+        text(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='audit_log'"
+        )
+    ).fetchone()
+    if result and "AUTOINCREMENT" not in result[0].upper():
+        with engine.begin() as conn:
+            conn.execute(text("ALTER TABLE audit_log RENAME TO audit_log_old"))
+            AuditLog.__table__.create(conn)
+            conn.execute(
+                text(
+                    "INSERT INTO audit_log (id, org_id, user_id, action, entity, entity_id, timestamp, ip_address, payload) "
+                    "SELECT id, org_id, user_id, action, entity, entity_id, timestamp, ip_address, payload FROM audit_log_old"
+                )
+            )
+            conn.execute(text("DROP TABLE audit_log_old"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,12 +7,14 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 from arkiv_app import create_app
 from arkiv_app.extensions import db
 from arkiv_app.models import Plan, Organization, User, Membership
+from arkiv_app.utils.audit import ensure_audit_log_schema
 
 @pytest.fixture
 def app():
     app = create_app('testing')
     with app.app_context():
         db.create_all()
+        ensure_audit_log_schema()
         plan = Plan(name='Test', storage_quota_gb=1, price_monthly=0)
         db.session.add(plan)
         db.session.commit()


### PR DESCRIPTION
## Summary
- enforce SQLite AUTOINCREMENT on `AuditLog`
- create helper to fix existing tables and call during app init
- update tests to run schema fix
- document new behaviour and instructions

## Testing
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684249278c0c8332bfe5dda5233f61c1