### PR TITLE
Use SQLite and local storage for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -851,6 +851,15 @@ Se o app mobile será feito em **MAUI**, convém expor APIs RESTful no backend p
      ```
    * O arquivo `celery_app.py` dentro de `arkiv_app/` configura o broker para o Redis, que dispara tarefas de thumbnail, OCR e relatórios agendados.
 
+### Ambiente de testes sem Redis/S3/Postgres
+
+Para rodar a suíte de testes ou experimentar a aplicação localmente sem depender
+de serviços externos, basta manter as variáveis padrão do `.env.example`. O
+`config.TestConfig` usa banco SQLite em memória e os uploads ficam em
+`instance/uploads`. Caso o Redis não esteja ativo, o `celery_app` cai
+automaticamente para o modo em memória, executando as tasks de forma síncrona.
+Assim é possível rodar `pytest` sem precisar de Postgres, S3 ou Redis.
+
 ---
 
 ## Roadmap

--- a/arkiv_app/celery_app.py
+++ b/arkiv_app/celery_app.py
@@ -1,16 +1,38 @@
-"""Simple Celery application configured with Redis."""
+"""Celery application with optional Redis fallback."""
+import os
 from celery import Celery
 from .config import config_by_name
+try:
+    from redis import Redis  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    Redis = None
 
 celery_app = Celery(__name__)
 
 
 def init_celery(config_name: str = "development") -> Celery:
-    """Initialize Celery with broker and backend from config."""
+    """Initialize Celery and fall back to in-memory if Redis is unavailable."""
     config = config_by_name[config_name]
-    celery_app.conf.broker_url = getattr(config, "CELERY_BROKER_URL", "redis://localhost:6379/0")
-    celery_app.conf.result_backend = getattr(config, "CELERY_RESULT_BACKEND", "redis://localhost:6379/0")
+    broker = getattr(config, "CELERY_BROKER_URL", "redis://localhost:6379/0")
+    backend = getattr(config, "CELERY_RESULT_BACKEND", broker)
+
+    celery_app.conf.broker_url = broker
+    celery_app.conf.result_backend = backend
+
+    eager = getattr(config, "CELERY_TASK_ALWAYS_EAGER", False)
+    if not eager and broker.startswith("redis"):
+        try:
+            if Redis is None:
+                raise RuntimeError("redis lib missing")
+            Redis.from_url(broker).ping()
+        except Exception:
+            eager = True
+    if eager:
+        celery_app.conf.broker_url = "memory://"
+        celery_app.conf.result_backend = "cache+memory://"
+        celery_app.conf.task_always_eager = True
+
     return celery_app
 
 
-init_celery()
+init_celery(os.getenv("FLASK_ENV", "development"))

--- a/arkiv_app/config.py
+++ b/arkiv_app/config.py
@@ -27,6 +27,9 @@ class TestConfig(Config):
     TESTING = True
     SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
     WTF_CSRF_ENABLED = False
+    CELERY_BROKER_URL = 'memory://'
+    CELERY_RESULT_BACKEND = 'cache+memory://'
+    CELERY_TASK_ALWAYS_EAGER = True
 
 config_by_name = {
     'development': DevelopmentConfig,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,10 @@ import os
 import sys
 import pytest
 
+os.environ.setdefault("FLASK_ENV", "testing")
+os.environ.setdefault("TESTING", "1")
+os.environ.setdefault("CELERY_ALWAYS_EAGER", "1")
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from arkiv_app import create_app


### PR DESCRIPTION
## Summary
- force Celery to use an in‑memory backend whenever Redis is missing
- configure TestConfig for SQLite and eager Celery tasks
- ensure tests set environment variables for this lightweight mode
- document the fallback behaviour in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -q -r requirements.txt` *(fails to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_684252d1b4688332b45f803baa088c06