### PR TITLE
Revamp UX with dark mode switch and form guards

### DIFF
--- a/arkiv_app/static/css/style.css
+++ b/arkiv_app/static/css/style.css
@@ -173,3 +173,16 @@ button:hover {
     margin-top: 80px;
   }
 }
+
+.skeleton-card {
+  background: linear-gradient(90deg, var(--card-bg) 25%, #e0e0e0 50%, var(--card-bg) 75%);
+  background-size: 200% 100%;
+  animation: skeleton 1.5s infinite;
+  height: 120px;
+  border-radius: 8px;
+}
+
+@keyframes skeleton {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}

--- a/arkiv_app/static/js/main.js
+++ b/arkiv_app/static/js/main.js
@@ -1,9 +1,13 @@
+const STORAGE_KEY = 'arkiv_theme';
+
 function applyTheme(theme) {
   document.documentElement.setAttribute('data-theme', theme);
-  localStorage.setItem('theme', theme);
+  localStorage.setItem(STORAGE_KEY, theme);
   const toggleBtn = document.querySelector('.theme-toggle');
   if (toggleBtn) {
-    toggleBtn.innerHTML = theme === 'dark' ? '<i class="bi bi-sun-fill"></i>' : '<i class="bi bi-moon-fill"></i>';
+    toggleBtn.innerHTML = theme === 'dark'
+      ? '<i class="bi bi-sun-fill"></i>'
+      : '<i class="bi bi-moon-fill"></i>';
   }
 }
 
@@ -14,10 +18,38 @@ function toggleTheme() {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  const saved = localStorage.getItem('theme') || 'light';
+  const saved = localStorage.getItem(STORAGE_KEY) || 'light';
   applyTheme(saved);
 
   document.querySelectorAll('.flash-item').forEach((el) => {
     setTimeout(() => el.remove(), 5000);
+  });
+
+  const forms = document.querySelectorAll('.guarded-form');
+  forms.forEach((form) => {
+    const submit = form.querySelector('[type="submit"]');
+    if (submit) submit.disabled = true;
+    const initial = new FormData(form);
+    const check = () => {
+      const current = new FormData(form);
+      let changed = false;
+      for (const [k, v] of current.entries()) {
+        if (initial.get(k) !== v) {
+          changed = true;
+          break;
+        }
+      }
+      const requiredFilled = Array.from(form.querySelectorAll('[required]')).every((el) => el.value.trim() !== '');
+      if (submit) submit.disabled = !(changed && requiredFilled);
+    };
+    form.addEventListener('input', check);
+    form.addEventListener('change', check);
+  });
+
+  document.addEventListener('keydown', (ev) => {
+    if (ev.key === 'Escape') {
+      const cancel = document.querySelector('.btn-cancel');
+      if (cancel) cancel.click();
+    }
   });
 });

--- a/arkiv_app/templates/asset/list.html
+++ b/arkiv_app/templates/asset/list.html
@@ -3,10 +3,13 @@
 {% block content %}
 <h1>Arquivos de {{ folder.name }}</h1>
 <p><a href="{{ url_for('folder.view_folder', folder_id=folder.id) }}">Voltar para pasta</a></p>
-<form method="post" enctype="multipart/form-data" class="card">
+<form method="post" enctype="multipart/form-data" class="card guarded-form">
   {{ form.hidden_tag() }}
   <div class="field">{{ form.file() }}</div>
-  <div>{{ form.submit(class_='btn') }}</div>
+  <div class="d-flex gap-2">
+    {{ form.submit(class_='btn') }}
+    <button type="button" class="btn btn-secondary btn-cancel" onclick="history.back()">Cancelar</button>
+  </div>
 </form>
 <ul>
   {% for asset in assets %}

--- a/arkiv_app/templates/base.html
+++ b/arkiv_app/templates/base.html
@@ -10,6 +10,10 @@
 </head>
 <body>
   {% include 'components/navbar.html' %}
+  <div class="container mt-3 d-flex align-items-center" id="breadcrumb">
+    <button type="button" class="btn btn-link p-0 me-2" onclick="history.back()"><i class="bi bi-arrow-left"></i> Voltar</button>
+    {% block breadcrumb %}{% endblock %}
+  </div>
   <main class="floating-container">
     {% with messages = get_flashed_messages() %}
       {% if messages %}

--- a/arkiv_app/templates/components/navbar.html
+++ b/arkiv_app/templates/components/navbar.html
@@ -5,7 +5,7 @@
       <input class="form-control" type="search" placeholder="Buscar" name="q" aria-label="Buscar">
     </form>
     <div class="d-flex align-items-center">
-      <button class="btn btn-link theme-toggle p-0 me-2" onclick="toggleTheme()" aria-label="Alterar tema"><i class="bi bi-moon-fill"></i></button>
+      <button class="btn btn-link theme-toggle p-0 me-2" onclick="toggleTheme()" aria-label="Alternar tema" aria-pressed="false"><i class="bi bi-moon-fill"></i></button>
       {% if current_user.is_authenticated %}
       <a class="btn btn-link" href="{{ url_for('auth.logout') }}">Sair</a>
       {% else %}

--- a/arkiv_app/templates/folder/form.html
+++ b/arkiv_app/templates/folder/form.html
@@ -2,11 +2,14 @@
 {% block title %}Pasta{% endblock %}
 {% block content %}
 <h1>Pasta</h1>
-<form method="post" class="card">
+<form method="post" class="card guarded-form">
   {{ form.hidden_tag() }}
   <div class="field">{{ form.library_id.label }} {{ form.library_id() }}</div>
   <div class="field">{{ form.parent_id.label }} {{ form.parent_id() }}</div>
-  <div class="field">{{ form.name.label }} {{ form.name(size=32) }}</div>
-  <div>{{ form.submit(class_='btn') }}</div>
+  <div class="field">{{ form.name.label }} {{ form.name(size=32, required=True) }}</div>
+  <div class="d-flex gap-2">
+    {{ form.submit(class_='btn') }}
+    <button type="button" class="btn btn-secondary btn-cancel" onclick="history.back()">Cancelar</button>
+  </div>
 </form>
 {% endblock %}

--- a/arkiv_app/templates/index.html
+++ b/arkiv_app/templates/index.html
@@ -1,10 +1,19 @@
 {% extends 'base.html' %}
 {% block title %}Início{% endblock %}
 {% block content %}
-<h1>Bem-vindo ao Arkiv</h1>
-<p>Gerencie suas bibliotecas e arquivos de forma eficiente.</p>
+<section class="text-center mb-5">
+  <h1 class="mb-3">Bem-vindo ao Arkiv</h1>
+  <form class="d-flex justify-content-center" role="search" action="{{ url_for('search.search_page') }}" method="get">
+    <input class="form-control" style="max-width:400px" type="search" placeholder="Buscar em tudo" name="q" aria-label="Buscar">
+  </form>
+</section>
+
 {% if current_user.is_authenticated %}
-<a href="{{ url_for('library.list_libraries') }}" class="btn">Bibliotecas</a>
+<div class="row text-center mb-4" style="gap:1rem; justify-content:center;">
+  <a href="{{ url_for('library.create_library') }}" class="btn"><i class="bi bi-collection"></i> Nova Biblioteca</a>
+  <a href="{{ url_for('folder.create_folder') }}" class="btn"><i class="bi bi-folder-plus"></i> Nova Pasta</a>
+</div>
+<a href="{{ url_for('library.list_libraries') }}" class="btn">Ir para Bibliotecas</a>
 {% else %}
 <a href="{{ url_for('auth.login') }}" class="btn">Entrar</a>
 {% endif %}

--- a/arkiv_app/templates/library/form.html
+++ b/arkiv_app/templates/library/form.html
@@ -2,10 +2,13 @@
 {% block title %}Biblioteca{% endblock %}
 {% block content %}
 <h1>Biblioteca</h1>
-<form method="post" class="card">
+<form method="post" class="card guarded-form">
   {{ form.hidden_tag() }}
-  <div class="field">{{ form.name.label }} {{ form.name(size=32) }}</div>
+  <div class="field">{{ form.name.label }} {{ form.name(size=32, required=True) }}</div>
   <div class="field">{{ form.description.label }} {{ form.description(cols=40, rows=4) }}</div>
-  <div>{{ form.submit(class_='btn') }}</div>
+  <div class="d-flex gap-2">
+    {{ form.submit(class_='btn') }}
+    <button type="button" class="btn btn-secondary btn-cancel" onclick="history.back()">Cancelar</button>
+  </div>
 </form>
 {% endblock %}

--- a/arkiv_app/templates/tag/form.html
+++ b/arkiv_app/templates/tag/form.html
@@ -2,10 +2,13 @@
 {% block title %}Tag{% endblock %}
 {% block content %}
 <h1>Tag</h1>
-<form method="post" class="card">
+<form method="post" class="card guarded-form">
   {{ form.hidden_tag() }}
-  <div class="field">{{ form.name.label }} {{ form.name(size=32) }}</div>
+  <div class="field">{{ form.name.label }} {{ form.name(size=32, required=True) }}</div>
   <div class="field">{{ form.color_hex.label }} {{ form.color_hex(size=10) }}</div>
-  <div>{{ form.submit(class_='btn') }}</div>
+  <div class="d-flex gap-2">
+    {{ form.submit(class_='btn') }}
+    <button type="button" class="btn btn-secondary btn-cancel" onclick="history.back()">Cancelar</button>
+  </div>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- overhaul theme toggle persistence
- add breadcrumb area with back button
- guard forms against accidental submit
- enhance navbar accessibility
- refresh home page hero layout
- add skeleton-card CSS helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684258639d548332ba3640bebe29952b