### PR TITLE
Improve Arkiv base UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,6 +647,8 @@ class AuditLog(db.Model):
 
    * **Grid de Thumbnails**: CSS Grid / Masonry para reflow suave de 320px a 4K.
    * **Navbar Fixa** com campo de busca e menu de usuário.
+   * **Tema Claro/Escuro** alternável pelo botão no topo. A escolha fica salva em `localStorage`.
+   * Fonte base **Inter** e botões `.btn-accent` padronizam o visual.
    * **Sidebar Colapsável** para filtros em telas maiores; em telas pequenas vira dropdown no topo.
 
 3. **Navegação por Teclado & Acessibilidade**

--- a/arkiv_app/static/css/style.css
+++ b/arkiv_app/static/css/style.css
@@ -1,9 +1,13 @@
 :root {
-  --brand-color: #28a0b0;
-  --brand-color-dark: #1d7580;
+  --accent: #28a0b0;
+  --accent-dark: #1d7580;
   --text-color: #333;
   --bg-color: #fff;
   --card-bg: #fff;
+  --bs-body-font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  --weight-normal: 400;
+  --weight-medium: 500;
+  --weight-semibold: 600;
 }
 
 [data-theme="dark"] {
@@ -15,13 +19,14 @@
 body {
   margin: 0;
   padding-top: 70px;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  font-family: var(--bs-body-font-family);
+  font-weight: var(--weight-normal);
   color: var(--text-color);
   background: var(--bg-color);
 }
 
 header {
-  background: var(--brand-color);
+  background: var(--accent);
   color: #fff;
 }
 
@@ -50,7 +55,7 @@ nav a:hover {
 }
 
 a {
-  color: var(--brand-color-dark);
+  color: var(--accent-dark);
   text-decoration: none;
 }
 
@@ -83,7 +88,7 @@ input, textarea, select, button {
 }
 
 button {
-  background-color: var(--brand-color);
+  background-color: var(--accent);
   color: #fff;
   border: none;
   cursor: pointer;
@@ -92,11 +97,11 @@ button {
 }
 
 button:hover {
-  background-color: var(--brand-color-dark);
+  background-color: var(--accent-dark);
 }
 
 .btn {
-  background-color: var(--brand-color);
+  background-color: var(--accent);
   color: #fff;
   border: none;
   cursor: pointer;
@@ -113,14 +118,14 @@ button:hover {
 }
 
 .btn:hover {
-  background-color: var(--brand-color-dark);
+  background-color: var(--accent-dark);
 }
 
 .card {
   background: var(--card-bg);
   padding: 1.5rem;
   border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  box-shadow: 0 2px 6px rgba(0,0,0,0.08);
   margin-bottom: 1rem;
 }
 
@@ -130,7 +135,7 @@ button:hover {
 }
 
 .flash li {
-  background: var(--brand-color);
+  background: var(--accent);
   color: #fff;
   margin-bottom: 0.5rem;
   padding: 0.5rem 2rem 0.5rem 0.5rem;
@@ -156,6 +161,34 @@ button:hover {
 }
 .navbar {
   box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+}
+
+.btn-accent {
+  background-color: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+  transition: all .24s cubic-bezier(.4,0,.2,1);
+}
+
+.btn-accent:hover {
+  background-color: var(--accent-dark);
+  border-color: var(--accent-dark);
+}
+
+.btn-outline-accent {
+  background-color: transparent;
+  color: var(--accent);
+  border: 1px solid var(--accent);
+  transition: all .24s cubic-bezier(.4,0,.2,1);
+}
+
+.btn-outline-accent:hover {
+  background-color: var(--accent);
+  color: #fff;
+}
+
+.card, .btn {
+  transition: all .24s cubic-bezier(.4,0,.2,1);
 }
 .floating-container {
   background: var(--card-bg);

--- a/arkiv_app/static/js/main.js
+++ b/arkiv_app/static/js/main.js
@@ -1,25 +1,4 @@
-const STORAGE_KEY = 'arkiv_theme';
-
-function applyTheme(theme) {
-  document.documentElement.setAttribute('data-theme', theme);
-  localStorage.setItem(STORAGE_KEY, theme);
-  const toggleBtn = document.querySelector('.theme-toggle');
-  if (toggleBtn) {
-    toggleBtn.innerHTML = theme === 'dark'
-      ? '<i class="bi bi-sun-fill"></i>'
-      : '<i class="bi bi-moon-fill"></i>';
-  }
-}
-
-function toggleTheme() {
-  const current = document.documentElement.getAttribute('data-theme');
-  const next = current === 'dark' ? 'light' : 'dark';
-  applyTheme(next);
-}
-
 document.addEventListener('DOMContentLoaded', () => {
-  const saved = localStorage.getItem(STORAGE_KEY) || 'light';
-  applyTheme(saved);
 
   document.querySelectorAll('.flash-item').forEach((el) => {
     setTimeout(() => el.remove(), 5000);

--- a/arkiv_app/static/js/theme.js
+++ b/arkiv_app/static/js/theme.js
@@ -1,0 +1,25 @@
+const STORAGE_KEY = 'arkiv_theme';
+
+function applyTheme(theme) {
+  document.documentElement.setAttribute('data-theme', theme);
+  localStorage.setItem(STORAGE_KEY, theme);
+  const toggleBtn = document.querySelector('.theme-toggle');
+  if (toggleBtn) {
+    toggleBtn.innerHTML = theme === 'dark'
+      ? '<i class="bi bi-sun-fill"></i>'
+      : '<i class="bi bi-moon-fill"></i>';
+    toggleBtn.setAttribute('aria-pressed', theme === 'dark');
+  }
+}
+
+function toggleTheme() {
+  const current = document.documentElement.getAttribute('data-theme');
+  const next = current === 'dark' ? 'light' : 'dark';
+  applyTheme(next);
+}
+
+(function initTheme() {
+  const preferred = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  const saved = localStorage.getItem(STORAGE_KEY) || preferred;
+  applyTheme(saved);
+})();

--- a/arkiv_app/templates/base.html
+++ b/arkiv_app/templates/base.html
@@ -4,6 +4,9 @@
   <meta charset="utf-8">
   <title>{{ title or 'Arkiv' }}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   {% block head %}{% endblock %}
@@ -14,7 +17,7 @@
     <button type="button" class="btn btn-link p-0 me-2" onclick="history.back()"><i class="bi bi-arrow-left"></i> Voltar</button>
     {% block breadcrumb %}{% endblock %}
   </div>
-  <main class="floating-container">
+  <main id="content" class="container-xl py-5">
     {% with messages = get_flashed_messages() %}
       {% if messages %}
       <ul class="flash">
@@ -26,6 +29,7 @@
     {% endwith %}
     {% block content %}{% endblock %}
   </main>
+  <script src="{{ url_for('static', filename='js/theme.js') }}"></script>
   <script src="{{ url_for('static', filename='js/main.js') }}"></script>
   {% block scripts %}{% endblock %}
 </body>

--- a/arkiv_app/templates/components/form_dirty_guard.html
+++ b/arkiv_app/templates/components/form_dirty_guard.html
@@ -1,0 +1,21 @@
+{% macro guard(form_selector='.guarded-form') %}
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('{{ form_selector }}').forEach((form) => {
+      const submit = form.querySelector('[type="submit"]');
+      if (submit) submit.disabled = true;
+      const initial = new FormData(form);
+      const check = () => {
+        const current = new FormData(form);
+        let changed = false;
+        for (const [k, v] of current.entries()) {
+          if (initial.get(k) !== v) { changed = true; break; }
+        }
+        submit.disabled = !(changed && form.checkValidity());
+      };
+      form.addEventListener('input', check);
+      form.addEventListener('change', check);
+    });
+  });
+</script>
+{% endmacro %}

--- a/arkiv_app/templates/components/navbar.html
+++ b/arkiv_app/templates/components/navbar.html
@@ -1,7 +1,7 @@
 <nav class="navbar fixed-top bg-light">
-  <div class="container-fluid">
-    <a class="navbar-brand" href="{{ url_for('main.index') }}">Arkiv</a>
-    <form class="d-none d-md-flex ms-auto me-3" role="search" action="{{ url_for('search.search_page') }}" method="get">
+  <div class="container-fluid d-flex align-items-center gap-3">
+    <a class="navbar-brand me-2" href="{{ url_for('main.index') }}">Arkiv</a>
+    <form class="flex-grow-1" role="search" hx-get="/search" hx-trigger="keyup changed delay:300ms" hx-target="#content" hx-push-url="true">
       <input class="form-control" type="search" placeholder="Buscar" name="q" aria-label="Buscar">
     </form>
     <div class="d-flex align-items-center">

--- a/arkiv_app/templates/folder/detail.html
+++ b/arkiv_app/templates/folder/detail.html
@@ -2,13 +2,13 @@
 {% block content %}
 <h1>{{ folder.name }}</h1>
 <p><a href="{{ url_for('library.show_library', lib_id=folder.library_id) }}">Voltar para biblioteca</a></p>
-<a href="{{ url_for('asset.upload_asset', folder_id=folder.id) }}" class="btn"><i class="bi bi-upload"></i> Enviar Arquivo</a>
-<a href="{{ url_for('folder.create_folder') }}?library_id={{ folder.library_id }}&parent_id={{ folder.id }}" class="btn"><i class="bi bi-folder-plus"></i> Nova Subpasta</a>
-<ul>
+<a href="{{ url_for('asset.upload_asset', folder_id=folder.id) }}" class="btn btn-accent mb-2"><i class="bi bi-upload"></i> Enviar Arquivo</a>
+<a href="{{ url_for('folder.create_folder') }}?library_id={{ folder.library_id }}&parent_id={{ folder.id }}" class="btn btn-accent mb-3"><i class="bi bi-folder-plus"></i> Nova Subpasta</a>
+<ul class="list-group">
   {% for sub in subfolders %}
-  <li><a href="{{ url_for('folder.view_folder', folder_id=sub.id) }}">{{ sub.name }}</a></li>
+  <li class="list-group-item"><a href="{{ url_for('folder.view_folder', folder_id=sub.id) }}">{{ sub.name }}</a></li>
   {% else %}
-  <li>Nenhuma subpasta</li>
+  <li class="list-group-item">Nenhuma subpasta</li>
   {% endfor %}
 </ul>
 {% endblock %}

--- a/arkiv_app/templates/folder/form.html
+++ b/arkiv_app/templates/folder/form.html
@@ -7,8 +7,10 @@
   <div class="field">{{ form.parent_id.label }} {{ form.parent_id() }}</div>
   <div class="field">{{ form.name.label }} {{ form.name(size=32, required=True) }}</div>
   <div class="d-flex gap-2">
-    {{ form.submit(class_='btn') }}
-    <button type="button" class="btn btn-secondary btn-cancel" onclick="history.back()">Cancelar</button>
+    {{ form.submit(class_='btn btn-accent') }}
+    <button type="button" class="btn btn-outline-secondary btn-cancel" onclick="history.back()">Cancelar</button>
   </div>
 </form>
+{% from 'components/form_dirty_guard.html' import guard %}
+{{ guard() }}
 {% endblock %}

--- a/arkiv_app/templates/home.html
+++ b/arkiv_app/templates/home.html
@@ -9,11 +9,11 @@
 
 {% if current_user.is_authenticated %}
 <div class="row text-center mb-4" style="gap:1rem; justify-content:center;">
-  <a href="{{ url_for('library.create_library') }}" class="btn"><i class="bi bi-collection"></i> Nova Biblioteca</a>
-  <a href="{{ url_for('folder.create_folder') }}" class="btn"><i class="bi bi-folder-plus"></i> Nova Pasta</a>
+  <a href="{{ url_for('library.create_library') }}" class="btn btn-accent"><i class="bi bi-collection"></i> Nova Biblioteca</a>
+  <a href="{{ url_for('folder.create_folder') }}" class="btn btn-accent"><i class="bi bi-folder-plus"></i> Nova Pasta</a>
 </div>
-<a href="{{ url_for('library.list_libraries') }}" class="btn">Ir para Bibliotecas</a>
+<a href="{{ url_for('library.list_libraries') }}" class="btn btn-outline-accent">Ir para Bibliotecas</a>
 {% else %}
-<a href="{{ url_for('auth.login') }}" class="btn">Entrar</a>
+<a href="{{ url_for('auth.login') }}" class="btn btn-accent">Entrar</a>
 {% endif %}
 {% endblock %}

--- a/arkiv_app/templates/library/detail.html
+++ b/arkiv_app/templates/library/detail.html
@@ -3,12 +3,14 @@
 <h1>{{ library.name }}</h1>
 <p><a href="{{ url_for('library.list_libraries') }}">Voltar para lista</a></p>
 <p>{{ library.description }}</p>
-<a href="{{ url_for('folder.create_folder') }}?library_id={{ library.id }}" class="btn"><i class="bi bi-folder-plus"></i> Nova Pasta</a>
-<ul>
+<a href="{{ url_for('folder.create_folder') }}?library_id={{ library.id }}" class="btn btn-accent mb-3"><i class="bi bi-folder-plus"></i> Nova Pasta</a>
+<ul class="list-group">
   {% for folder in folders %}
-  <li><a href="{{ url_for('folder.view_folder', folder_id=folder.id) }}">{{ folder.name }}</a></li>
+  <li class="list-group-item d-flex justify-content-between align-items-center">
+    <a href="{{ url_for('folder.view_folder', folder_id=folder.id) }}">{{ folder.name }}</a>
+  </li>
   {% else %}
-  <li>Nenhuma pasta</li>
+  <li class="list-group-item">Nenhuma pasta</li>
   {% endfor %}
 </ul>
 {% endblock %}

--- a/arkiv_app/templates/library/form.html
+++ b/arkiv_app/templates/library/form.html
@@ -6,8 +6,10 @@
   <div class="field">{{ form.name.label }} {{ form.name(size=32, required=True) }}</div>
   <div class="field">{{ form.description.label }} {{ form.description(cols=40, rows=4) }}</div>
   <div class="d-flex gap-2">
-    {{ form.submit(class_='btn') }}
-    <button type="button" class="btn btn-secondary btn-cancel" onclick="history.back()">Cancelar</button>
+    {{ form.submit(class_='btn btn-accent') }}
+    <button type="button" class="btn btn-outline-secondary btn-cancel" onclick="history.back()">Cancelar</button>
   </div>
 </form>
+{% from 'components/form_dirty_guard.html' import guard %}
+{{ guard() }}
 {% endblock %}

--- a/arkiv_app/templates/library/list.html
+++ b/arkiv_app/templates/library/list.html
@@ -1,18 +1,20 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Bibliotecas</h1>
-<a href="{{ url_for('library.create_library') }}" class="btn"><i class="bi bi-plus-circle"></i> Nova Biblioteca</a>
-<ul>
+<a href="{{ url_for('library.create_library') }}" class="btn btn-accent mb-3"><i class="bi bi-plus-circle"></i> Nova Biblioteca</a>
+<ul class="list-group">
   {% for lib in libraries %}
-  <li class="card" style="margin-bottom:1rem; list-style:none;">
-    <a href="{{ url_for('library.show_library', lib_id=lib.id) }}">{{ lib.name }}</a> -
-    <a href="{{ url_for('library.edit_library', lib_id=lib.id) }}"><i class="bi bi-pencil"></i> Editar</a>
-    <form action="{{ url_for('library.delete_library', lib_id=lib.id) }}" method="post" style="display:inline">
-      <button type="submit" class="btn"><i class="bi bi-trash"></i> Excluir</button>
-    </form>
+  <li class="list-group-item d-flex justify-content-between align-items-center">
+    <span><a href="{{ url_for('library.show_library', lib_id=lib.id) }}">{{ lib.name }}</a></span>
+    <div class="btn-group">
+      <a href="{{ url_for('library.edit_library', lib_id=lib.id) }}" class="btn btn-outline-secondary btn-sm"><i class="bi bi-pencil"></i></a>
+      <form action="{{ url_for('library.delete_library', lib_id=lib.id) }}" method="post" class="d-inline">
+        <button type="submit" class="btn btn-outline-danger btn-sm"><i class="bi bi-trash"></i></button>
+      </form>
+    </div>
   </li>
   {% else %}
-  <li>Nenhuma biblioteca</li>
+  <li class="list-group-item">Nenhuma biblioteca</li>
   {% endfor %}
 </ul>
 {% endblock %}

--- a/arkiv_app/templates/search/results.html
+++ b/arkiv_app/templates/search/results.html
@@ -1,15 +1,15 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Resultados para "{{ query }}"</h1>
-<ul>
+<ul class="list-group">
   {% for a in assets %}
-  <li class="card">Arquivo: {{ a.filename_orig }}</li>
+  <li class="list-group-item">Arquivo: {{ a.filename_orig }}</li>
   {% endfor %}
   {% for f in folders %}
-  <li class="card">Pasta: {{ f.name }}</li>
+  <li class="list-group-item">Pasta: {{ f.name }}</li>
   {% endfor %}
   {% for l in libraries %}
-  <li class="card">Biblioteca: {{ l.name }}</li>
+  <li class="list-group-item">Biblioteca: {{ l.name }}</li>
   {% endfor %}
 </ul>
 {% endblock %}

--- a/arkiv_app/templates/tag/form.html
+++ b/arkiv_app/templates/tag/form.html
@@ -6,8 +6,10 @@
   <div class="field">{{ form.name.label }} {{ form.name(size=32, required=True) }}</div>
   <div class="field">{{ form.color_hex.label }} {{ form.color_hex(size=10) }}</div>
   <div class="d-flex gap-2">
-    {{ form.submit(class_='btn') }}
-    <button type="button" class="btn btn-secondary btn-cancel" onclick="history.back()">Cancelar</button>
+    {{ form.submit(class_='btn btn-accent') }}
+    <button type="button" class="btn btn-outline-secondary btn-cancel" onclick="history.back()">Cancelar</button>
   </div>
 </form>
+{% from 'components/form_dirty_guard.html' import guard %}
+{{ guard() }}
 {% endblock %}

--- a/arkiv_app/templates/tag/list.html
+++ b/arkiv_app/templates/tag/list.html
@@ -1,17 +1,20 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Tags</h1>
-<a href="{{ url_for('tag.create_tag') }}" class="btn"><i class="bi bi-plus-circle"></i> Nova Tag</a>
-<ul>
+<a href="{{ url_for('tag.create_tag') }}" class="btn btn-accent mb-3"><i class="bi bi-plus-circle"></i> Nova Tag</a>
+<ul class="list-group">
   {% for t in tags %}
-  <li class="card" style="margin-bottom:1rem; list-style:none;">
-    {{ t.name }} - <a href="{{ url_for('tag.edit_tag', tag_id=t.id) }}"><i class="bi bi-pencil"></i> Editar</a>
-    <form action="{{ url_for('tag.delete_tag', tag_id=t.id) }}" method="post" style="display:inline">
-      <button type="submit" class="btn"><i class="bi bi-trash"></i> Excluir</button>
-    </form>
+  <li class="list-group-item d-flex justify-content-between align-items-center">
+    <span>{{ t.name }}</span>
+    <div class="btn-group">
+      <a href="{{ url_for('tag.edit_tag', tag_id=t.id) }}" class="btn btn-outline-secondary btn-sm"><i class="bi bi-pencil"></i></a>
+      <form action="{{ url_for('tag.delete_tag', tag_id=t.id) }}" method="post" class="d-inline">
+        <button type="submit" class="btn btn-outline-danger btn-sm"><i class="bi bi-trash"></i></button>
+      </form>
+    </div>
   </li>
   {% else %}
-  <li>Nenhuma tag</li>
+  <li class="list-group-item">Nenhuma tag</li>
   {% endfor %}
 </ul>
 {% endblock %}


### PR DESCRIPTION
## Summary
- overhaul base layout for a flex navbar and containerized main area
- introduce Inter font and CSS tokens for accent colors
- add reusable dirty form guard and theme toggle script
- refine list views with Bootstrap list groups
- document dark mode and accent buttons in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684261b95c588332a13c278ee2ad688a