### PR TITLE
Fix missing actions for cancel/back buttons

### DIFF
--- a/arkiv_app/templates/admin/logs.html
+++ b/arkiv_app/templates/admin/logs.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Últimos Logs</h1>
+<p><a href="{{ url_for('admin.index') }}">Voltar</a></p>
 <table class="card" style="width:100%">
   <tr><th>Org</th><th>Usuário</th><th>Ação</th><th>Entidade</th><th>ID</th><th>Data</th></tr>
   {% for l in logs %}

--- a/arkiv_app/templates/admin/orgs.html
+++ b/arkiv_app/templates/admin/orgs.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Organizações</h1>
+<p><a href="{{ url_for('admin.index') }}">Voltar</a></p>
 <ul>
   {% for org in orgs %}
   <li class="card">{{ org.name }} ({{ org.slug }})</li>

--- a/arkiv_app/templates/admin/plans.html
+++ b/arkiv_app/templates/admin/plans.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Planos</h1>
+<p><a href="{{ url_for('admin.index') }}">Voltar</a></p>
 <ul>
   {% for plan in plans %}
   <li class="card">{{ plan.name }} - {{ plan.storage_quota_gb }}GB</li>

--- a/arkiv_app/templates/admin/users.html
+++ b/arkiv_app/templates/admin/users.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Usuários</h1>
+<p><a href="{{ url_for('admin.index') }}">Voltar</a></p>
 <table class="card" style="width:100%">
   <tr><th>Nome</th><th>Email</th><th>Ativo</th><th>Admin</th></tr>
   {% for u in users %}

--- a/arkiv_app/templates/asset/list.html
+++ b/arkiv_app/templates/asset/list.html
@@ -7,7 +7,7 @@
   <div class="field">{{ form.file() }}</div>
   <div class="d-flex gap-2">
     {{ form.submit(class_='btn') }}
-    <button type="button" class="btn btn-secondary btn-cancel" onclick="history.back()">Cancelar</button>
+    <a href="{{ url_for('folder.view_folder', folder_id=folder.id) }}" class="btn btn-secondary btn-cancel">Cancelar</a>
   </div>
 </form>
 <ul>

--- a/arkiv_app/templates/auth/login.html
+++ b/arkiv_app/templates/auth/login.html
@@ -9,8 +9,9 @@
     <div class="field">
       {{ form.password.label }} {{ form.password(size=32) }}
     </div>
-    <div>
+    <div class="d-flex gap-2">
       {{ form.submit(class_='btn') }}
+      <a href="{{ url_for('main.index') }}" class="btn btn-outline-secondary">Voltar</a>
     </div>
   </form>
 </div>

--- a/arkiv_app/templates/base.html
+++ b/arkiv_app/templates/base.html
@@ -14,7 +14,7 @@
 <body>
   {% include 'components/navbar.html' %}
   <div class="container mt-3 d-flex align-items-center" id="breadcrumb">
-    <button type="button" class="btn btn-link p-0 me-2" onclick="history.back()"><i class="bi bi-arrow-left"></i> Voltar</button>
+    <a href="{{ request.referrer or url_for('main.index') }}" class="btn btn-link p-0 me-2"><i class="bi bi-arrow-left"></i> Voltar</a>
     {% block breadcrumb %}{% endblock %}
   </div>
   <main id="content" class="container-xl py-5">

--- a/arkiv_app/templates/folder/form.html
+++ b/arkiv_app/templates/folder/form.html
@@ -8,7 +8,7 @@
   <div class="field">{{ form.name.label }} {{ form.name(size=32, required=True) }}</div>
   <div class="d-flex gap-2">
     {{ form.submit(class_='btn btn-accent') }}
-    <button type="button" class="btn btn-outline-secondary btn-cancel" onclick="history.back()">Cancelar</button>
+    <a href="{{ url_for('library.list_libraries') }}" class="btn btn-outline-secondary btn-cancel">Cancelar</a>
   </div>
 </form>
 {% from 'components/form_dirty_guard.html' import guard %}

--- a/arkiv_app/templates/library/form.html
+++ b/arkiv_app/templates/library/form.html
@@ -7,7 +7,7 @@
   <div class="field">{{ form.description.label }} {{ form.description(cols=40, rows=4) }}</div>
   <div class="d-flex gap-2">
     {{ form.submit(class_='btn btn-accent') }}
-    <button type="button" class="btn btn-outline-secondary btn-cancel" onclick="history.back()">Cancelar</button>
+    <a href="{{ url_for('library.list_libraries') }}" class="btn btn-outline-secondary btn-cancel">Cancelar</a>
   </div>
 </form>
 {% from 'components/form_dirty_guard.html' import guard %}

--- a/arkiv_app/templates/tag/form.html
+++ b/arkiv_app/templates/tag/form.html
@@ -7,7 +7,7 @@
   <div class="field">{{ form.color_hex.label }} {{ form.color_hex(size=10) }}</div>
   <div class="d-flex gap-2">
     {{ form.submit(class_='btn btn-accent') }}
-    <button type="button" class="btn btn-outline-secondary btn-cancel" onclick="history.back()">Cancelar</button>
+    <a href="{{ url_for('tag.list_tags') }}" class="btn btn-outline-secondary btn-cancel">Cancelar</a>
   </div>
 </form>
 {% from 'components/form_dirty_guard.html' import guard %}


### PR DESCRIPTION
## Summary
- add explicit routes to cancel links in forms
- add back links to admin pages
- add back link on login page
- make breadcrumb 'Voltar' link go to previous or home page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68426f70ffa083329468cb5db60addde