### PR TITLE
Improve interface with floating container

### DIFF
--- a/arkiv_app/static/css/style.css
+++ b/arkiv_app/static/css/style.css
@@ -45,7 +45,7 @@ nav {
 }
 
 nav a {
-  color: #fff;
+  color: inherit;
   font-weight: bold;
   text-decoration: none;
 }
@@ -63,11 +63,6 @@ a:hover {
   text-decoration: underline;
 }
 
-.container {
-  width: 90%;
-  max-width: 960px;
-  margin: 2rem auto;
-}
 
 form {
   display: flex;

--- a/arkiv_app/templates/base.html
+++ b/arkiv_app/templates/base.html
@@ -7,6 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   {% block head %}{% endblock %}
@@ -17,18 +18,21 @@
     <a href="{{ request.referrer or url_for('main.index') }}" class="btn btn-link p-0 me-2"><i class="bi bi-arrow-left"></i> Voltar</a>
     {% block breadcrumb %}{% endblock %}
   </div>
-  <main id="content" class="container-xl py-5">
-    {% with messages = get_flashed_messages() %}
-      {% if messages %}
-      <ul class="flash">
-        {% for m in messages %}
-        <li class="flash-item">{{ m }} <button class="flash-close" aria-label="Fechar" onclick="this.parentElement.remove()">&times;</button></li>
-        {% endfor %}
-      </ul>
-      {% endif %}
-    {% endwith %}
-    {% block content %}{% endblock %}
+  <main id="content" class="py-5">
+    <div class="floating-container">
+      {% with messages = get_flashed_messages() %}
+        {% if messages %}
+        <ul class="flash">
+          {% for m in messages %}
+          <li class="flash-item">{{ m }} <button class="flash-close" aria-label="Fechar" onclick="this.parentElement.remove()">&times;</button></li>
+          {% endfor %}
+        </ul>
+        {% endif %}
+      {% endwith %}
+      {% block content %}{% endblock %}
+    </div>
   </main>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script src="{{ url_for('static', filename='js/theme.js') }}"></script>
   <script src="{{ url_for('static', filename='js/main.js') }}"></script>
   {% block scripts %}{% endblock %}


### PR DESCRIPTION
## Summary
- add Bootstrap CSS/JS
- wrap page contents in a floating container
- keep navbar links inheriting text color

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6842712b0d688332bd062df2ed91f07d