### PR TITLE
Add modern login features with OAuth and password recovery

### DIFF
--- a/arkiv_app/__init__.py
+++ b/arkiv_app/__init__.py
@@ -7,6 +7,7 @@ from flask_login import current_user
 
 from .utils import current_org_id
 from .utils.audit import ensure_audit_log_schema
+from .auth.routes import oauth
 
 def create_app(config_name='development'):
     app = Flask(__name__)
@@ -27,6 +28,8 @@ def create_app(config_name='development'):
                         scope.set_tag('org_id', org_id)
 
     init_extensions(app)
+    if oauth:
+        oauth.init_app(app)
 
     from .main.routes import main_bp
     from .api import api_bp

--- a/arkiv_app/auth/forms.py
+++ b/arkiv_app/auth/forms.py
@@ -1,9 +1,21 @@
 from flask_wtf import FlaskForm
-from wtforms import StringField, PasswordField, SubmitField
-from wtforms.validators import DataRequired, Email
+from wtforms import StringField, PasswordField, SubmitField, BooleanField
+from wtforms.validators import DataRequired, Email, Length
 
 
 class LoginForm(FlaskForm):
     email = StringField('Email', validators=[DataRequired(), Email()])
     password = PasswordField('Senha', validators=[DataRequired()])
+    remember = BooleanField('Continuar logado')
+    token = StringField('Código 2FA')
     submit = SubmitField('Entrar')
+
+
+class ResetRequestForm(FlaskForm):
+    email = StringField('Email', validators=[DataRequired(), Email()])
+    submit = SubmitField('Enviar link')
+
+
+class ResetPasswordForm(FlaskForm):
+    password = PasswordField('Nova senha', validators=[DataRequired(), Length(min=8)])
+    submit = SubmitField('Definir senha')

--- a/arkiv_app/auth/routes.py
+++ b/arkiv_app/auth/routes.py
@@ -1,10 +1,29 @@
-from flask import render_template, redirect, url_for, flash, request
+import os
+from flask import render_template, redirect, url_for, flash, request, current_app
 from flask_login import login_user, logout_user
+from itsdangerous import URLSafeTimedSerializer, BadSignature
+from datetime import datetime
 
 from ..models import User
 from ..extensions import db, login_manager, limiter
 from . import auth_bp
-from .forms import LoginForm
+from .forms import LoginForm, ResetRequestForm, ResetPasswordForm
+
+try:
+    from authlib.integrations.flask_client import OAuth
+    oauth = OAuth()
+    google = oauth.register(
+        name='google',
+        client_id=os.environ.get('GOOGLE_CLIENT_ID'),
+        client_secret=os.environ.get('GOOGLE_CLIENT_SECRET'),
+        access_token_url='https://oauth2.googleapis.com/token',
+        authorize_url='https://accounts.google.com/o/oauth2/auth',
+        client_kwargs={'scope': 'openid email profile'},
+    )
+except Exception:  # pragma: no cover - optional dependency
+    oauth = None
+    google = None
+from ..utils.email_sender import send_reset_email
 
 
 @login_manager.user_loader
@@ -19,7 +38,13 @@ def login():
     if form.validate_on_submit():
         user = User.query.filter_by(email=form.email.data).first()
         if user and user.check_password(form.password.data):
-            login_user(user)
+            if user.mfa_enabled:
+                if not form.token.data or not user.verify_totp(form.token.data):
+                    flash('Código de 2FA inválido')
+                    return render_template('auth/login.html', form=form, title='Entrar')
+            user.last_login = datetime.utcnow()
+            db.session.commit()
+            login_user(user, remember=form.remember.data)
             return redirect(url_for('library.list_libraries'))
         flash('Credenciais inválidas')
     return render_template('auth/login.html', form=form, title='Entrar')
@@ -29,3 +54,67 @@ def login():
 def logout():
     logout_user()
     return redirect(url_for('auth.login'))
+
+
+@auth_bp.route('/login/google')
+def google_login():
+    if not google:
+        flash('Google OAuth não configurado')
+        return redirect(url_for('auth.login'))
+    redirect_uri = url_for('auth.google_authorized', _external=True)
+    return google.authorize_redirect(redirect_uri)
+
+
+@auth_bp.route('/login/google/authorized')
+def google_authorized():
+    if not google:
+        flash('Google OAuth não configurado')
+        return redirect(url_for('auth.login'))
+    token = google.authorize_access_token()
+    resp = google.get('userinfo')
+    user_info = resp.json()
+    user = User.query.filter_by(email=user_info['email']).first()
+    if not user:
+        user = User(name=user_info['name'], email=user_info['email'])
+        user.set_password(os.urandom(16).hex())
+        db.session.add(user)
+        db.session.commit()
+    login_user(user, remember=True)
+    return redirect(url_for('library.list_libraries'))
+
+
+def _token_serializer():
+    return URLSafeTimedSerializer(current_app.config['SECRET_KEY'], salt='pwd-reset')
+
+
+@auth_bp.route('/reset-password', methods=['GET', 'POST'])
+def reset_request():
+    form = ResetRequestForm()
+    if form.validate_on_submit():
+        user = User.query.filter_by(email=form.email.data).first()
+        if user:
+            token = _token_serializer().dumps(user.id)
+            send_reset_email(current_app, user, token)
+        flash('Se o email estiver cadastrado, enviaremos instruções.')
+        return redirect(url_for('auth.login'))
+    return render_template('auth/reset_request.html', form=form, title='Recuperar senha')
+
+
+@auth_bp.route('/reset/<token>', methods=['GET', 'POST'])
+def reset_with_token(token):
+    form = ResetPasswordForm()
+    try:
+        user_id = _token_serializer().loads(token, max_age=3600)
+    except BadSignature:
+        flash('Link inválido ou expirado')
+        return redirect(url_for('auth.login'))
+    user = User.query.get(user_id)
+    if not user:
+        flash('Usuário não encontrado')
+        return redirect(url_for('auth.login'))
+    if form.validate_on_submit():
+        user.set_password(form.password.data)
+        db.session.commit()
+        flash('Senha atualizada')
+        return redirect(url_for('auth.login'))
+    return render_template('auth/reset_password.html', form=form, title='Definir nova senha')

--- a/arkiv_app/templates/auth/login.html
+++ b/arkiv_app/templates/auth/login.html
@@ -1,18 +1,42 @@
 {% extends 'base.html' %}
 {% block content %}
 <div class="d-flex justify-content-center">
-  <form method="post" class="card shadow-soft rounded-md" style="max-width: 400px; width:100%;">
+  <form method="post" class="card p-4 shadow-sm" style="max-width: 420px; width:100%;">
     {{ form.hidden_tag() }}
-    <div class="field">
-      {{ form.email.label }} {{ form.email(size=32) }}
+    <h1 class="h4 mb-3 text-center">Entrar</h1>
+    <div class="mb-3">
+      {{ form.email.label(class_='form-label') }}
+      {{ form.email(class_='form-control', placeholder='seu@email.com', required=true) }}
     </div>
-    <div class="field">
-      {{ form.password.label }} {{ form.password(size=32) }}
+    <div class="mb-3">
+      {{ form.password.label(class_='form-label') }}
+      {{ form.password(class_='form-control', placeholder='Senha', required=true) }}
     </div>
-    <div class="d-flex gap-2">
-      {{ form.submit(class_='btn') }}
-      <a href="{{ url_for('main.index') }}" class="btn btn-outline-secondary">Voltar</a>
+    <div class="mb-3" id="totp-field" {% if not form.token.data %}style="display:none"{% endif %}>
+      {{ form.token.label(class_='form-label') }}
+      {{ form.token(class_='form-control', autocomplete='one-time-code') }}
+    </div>
+    <div class="form-check mb-3">
+      {{ form.remember(class_='form-check-input') }}
+      {{ form.remember.label(class_='form-check-label') }}
+    </div>
+    <div class="d-grid gap-2 mb-3">
+      {{ form.submit(class_='btn btn-primary') }}
+      {% if google %}
+      <a href="{{ url_for('auth.google_login') }}" class="btn btn-outline-secondary"><i class="bi bi-google"></i> Entrar com Google</a>
+      {% endif %}
+    </div>
+    <div class="text-center">
+      <a href="{{ url_for('auth.reset_request') }}">Esqueci minha senha</a>
     </div>
   </form>
 </div>
+<script>
+  const totpInput = document.querySelector('#totp-field');
+  document.querySelector('input[name="password"]').addEventListener('change', () => {
+    if (totpInput && totpInput.style.display === 'none') {
+      totpInput.style.display = '';
+    }
+  });
+</script>
 {% endblock %}

--- a/arkiv_app/templates/auth/reset_password.html
+++ b/arkiv_app/templates/auth/reset_password.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="d-flex justify-content-center">
+  <form method="post" class="card p-4 shadow-sm" style="max-width:420px;width:100%;">
+    {{ form.hidden_tag() }}
+    <h1 class="h4 mb-3 text-center">Definir nova senha</h1>
+    <div class="mb-3">
+      {{ form.password.label(class_='form-label') }}
+      {{ form.password(class_='form-control') }}
+    </div>
+    <div class="d-grid gap-2">
+      {{ form.submit(class_='btn btn-primary') }}
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/arkiv_app/templates/auth/reset_request.html
+++ b/arkiv_app/templates/auth/reset_request.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="d-flex justify-content-center">
+  <form method="post" class="card p-4 shadow-sm" style="max-width:420px;width:100%;">
+    {{ form.hidden_tag() }}
+    <h1 class="h4 mb-3 text-center">Recuperar senha</h1>
+    <div class="mb-3">
+      {{ form.email.label(class_='form-label') }}
+      {{ form.email(class_='form-control', placeholder='seu@email.com') }}
+    </div>
+    <div class="d-grid gap-2">
+      {{ form.submit(class_='btn btn-primary') }}
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/arkiv_app/utils/email_sender.py
+++ b/arkiv_app/utils/email_sender.py
@@ -1,5 +1,6 @@
 """Utility for sending emails using Flask-Mail."""
 from flask_mail import Mail, Message
+from flask import url_for
 
 mail = Mail()
 
@@ -10,3 +11,9 @@ def send_email(app, to: str, subject: str, body: str) -> None:
     with app.app_context():
         msg = Message(subject=subject, recipients=[to], body=body)
         mail.send(msg)
+
+
+def send_reset_email(app, user, token: str) -> None:
+    reset_link = url_for('auth.reset_with_token', token=token, _external=True)
+    body = f'Clique no link para redefinir sua senha: {reset_link}'
+    send_email(app, user.email, 'Recuperar senha', body)


### PR DESCRIPTION
## Summary
- add 2FA TOTP support and remember-me
- integrate optional Google OAuth login
- record last login and add password recovery flow
- update login template and add reset password pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684310fe7eac8332aa2729af6ed8b60d