### PR TITLE
Hide search and logout in login navbar

### DIFF
--- a/arkiv_app/auth/routes.py
+++ b/arkiv_app/auth/routes.py
@@ -41,13 +41,13 @@ def login():
             if user.mfa_enabled:
                 if not form.token.data or not user.verify_totp(form.token.data):
                     flash('Código de 2FA inválido')
-                    return render_template('auth/login.html', form=form, title='Entrar')
+                    return render_template('auth/login.html', form=form, title='Entrar', login_page=True)
             user.last_login = datetime.utcnow()
             db.session.commit()
             login_user(user, remember=form.remember.data)
             return redirect(url_for('library.list_libraries'))
         flash('Credenciais inválidas')
-    return render_template('auth/login.html', form=form, title='Entrar')
+    return render_template('auth/login.html', form=form, title='Entrar', login_page=True)
 
 
 @auth_bp.route('/logout')

--- a/arkiv_app/templates/base.html
+++ b/arkiv_app/templates/base.html
@@ -14,10 +14,12 @@
 </head>
 <body>
   {% include 'components/navbar.html' %}
+  {% if not login_page %}
   <div class="container mt-3 d-flex align-items-center" id="breadcrumb">
     <a href="{{ request.referrer or url_for('main.index') }}" class="btn btn-link p-0 me-2" onclick="if (history.length > 1) { history.back(); return false; }"><i class="bi bi-arrow-left"></i> Voltar</a>
     {% block breadcrumb %}{% endblock %}
   </div>
+  {% endif %}
   <main id="content" class="py-5">
     <div class="floating-container">
       {% with messages = get_flashed_messages() %}

--- a/arkiv_app/templates/components/navbar.html
+++ b/arkiv_app/templates/components/navbar.html
@@ -1,15 +1,19 @@
 <nav class="navbar fixed-top bg-light">
   <div class="container-fluid d-flex align-items-center gap-3">
     <a class="navbar-brand me-2" href="{{ url_for('main.index') }}">Arkiv</a>
+    {% if not login_page %}
     <form class="flex-grow-1" role="search" hx-get="/search" hx-trigger="keyup changed delay:300ms" hx-target="#content" hx-push-url="true">
       <input class="form-control" type="search" placeholder="Buscar" name="q" aria-label="Buscar">
     </form>
+    {% endif %}
     <div class="d-flex align-items-center">
       <button class="btn btn-link theme-toggle p-0 me-2" onclick="toggleTheme()" aria-label="Alternar tema" aria-pressed="false"><i class="bi bi-moon-fill"></i></button>
-      {% if current_user.is_authenticated %}
-      <a class="btn btn-link" href="{{ url_for('auth.logout') }}">Sair</a>
-      {% else %}
-      <a class="btn btn-link" href="{{ url_for('auth.login') }}">Entrar</a>
+      {% if not login_page %}
+        {% if current_user.is_authenticated %}
+        <a class="btn btn-link" href="{{ url_for('auth.logout') }}">Sair</a>
+        {% else %}
+        <a class="btn btn-link" href="{{ url_for('auth.login') }}">Entrar</a>
+        {% endif %}
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
## Summary
- suppress back button and search in login navbar
- show theme toggle only on login
- update login route to set a flag for navbar

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68431403f01483328d2e1cae94e8fc72