### PR TITLE
Refatora tela de biblioteca

### DIFF
--- a/arkiv_app/library/routes.py
+++ b/arkiv_app/library/routes.py
@@ -65,10 +65,18 @@ def list_libraries():
 def show_library(lib_id):
     lib = Library.query.get_or_404(lib_id)
     folders = Folder.query.filter_by(library_id=lib_id, parent_id=None).all()
+    assets = (
+        Asset.query
+        .filter_by(library_id=lib_id)
+        .order_by(Asset.created_at.desc())
+        .limit(20)
+        .all()
+    )
     return render_template(
         "library/detail.html",
         library=lib,
         folders=folders,
+        assets=assets,
         title=lib.name,
     )
 

--- a/arkiv_app/static/css/style.css
+++ b/arkiv_app/static/css/style.css
@@ -294,3 +294,36 @@ button:hover, .btn:hover {
 .library-thumbs img {
   object-fit: cover;
 }
+
+.asset-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.asset-card {
+  background: var(--card-bg);
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.05);
+  overflow: hidden;
+  transition: transform .2s, box-shadow .2s;
+}
+
+.asset-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+}
+
+.asset-card img {
+  width: 100%;
+  height: 120px;
+  object-fit: cover;
+}
+
+.asset-info {
+  padding: 0.5rem;
+  font-size: 0.875rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/arkiv_app/templates/library/detail.html
+++ b/arkiv_app/templates/library/detail.html
@@ -1,16 +1,55 @@
 {% extends 'base.html' %}
+{% block breadcrumb %}
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb mb-0">
+    <li class="breadcrumb-item"><a href="{{ url_for('library.list_libraries') }}">Bibliotecas</a></li>
+    <li class="breadcrumb-item active" aria-current="page">{{ library.name }}</li>
+  </ol>
+</nav>
+{% endblock %}
 {% block content %}
-<h1>{{ library.name }}</h1>
-<p><a href="{{ url_for('library.list_libraries') }}">Voltar para lista</a></p>
-<p>{{ library.description }}</p>
-<a href="{{ url_for('folder.create_folder') }}?library_id={{ library.id }}" class="btn btn-accent mb-3"><i class="bi bi-folder-plus"></i> Nova Pasta</a>
-<ul class="list-group">
-  {% for folder in folders %}
-  <li class="list-group-item d-flex justify-content-between align-items-center">
-    <a href="{{ url_for('folder.view_folder', folder_id=folder.id) }}">{{ folder.name }}</a>
-  </li>
-  {% else %}
-  <li class="list-group-item">Nenhuma pasta</li>
-  {% endfor %}
-</ul>
+<div class="d-flex justify-content-between align-items-start flex-column flex-sm-row gap-3 mb-4">
+  <div>
+    <h1 class="mb-0">{{ library.name }}</h1>
+    {% if library.description %}
+    <p class="text-muted mb-0">{{ library.description }}</p>
+    {% endif %}
+  </div>
+  <a href="{{ url_for('library.edit_library', lib_id=library.id) }}" class="btn btn-outline-accent"><i class="bi bi-pencil"></i> Editar Biblioteca</a>
+</div>
+<div class="row">
+  <div class="col-md-3 mb-4">
+    <div class="d-flex justify-content-between align-items-center mb-2">
+      <h6 class="mb-0">Pastas</h6>
+      <a href="{{ url_for('folder.create_folder') }}?library_id={{ library.id }}" class="btn btn-sm btn-accent" aria-label="Nova Pasta"><i class="bi bi-folder-plus"></i></a>
+    </div>
+    <ul class="list-group folder-list">
+      {% for folder in folders %}
+      <li class="list-group-item"><a href="{{ url_for('folder.view_folder', folder_id=folder.id) }}">{{ folder.name }}</a></li>
+      {% else %}
+      <li class="list-group-item text-muted">Nenhuma pasta</li>
+      {% endfor %}
+    </ul>
+  </div>
+  <div class="col-md-9">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h6 class="mb-0">Arquivos recentes</h6>
+    </div>
+    {% if assets %}
+    <div class="asset-grid">
+      {% for a in assets %}
+      <div class="asset-card">
+        <img src="{{ url_for('static', filename='img/avatar.svg') }}" alt="thumb">
+        <div class="asset-info">{{ a.filename_orig }}</div>
+      </div>
+      {% endfor %}
+    </div>
+    {% else %}
+    <div class="text-center p-5 border rounded bg-light">
+      <p class="lead mb-3">Nada aqui ainda. Faça seu primeiro upload!</p>
+      <a href="{{ url_for('folder.create_folder') }}?library_id={{ library.id }}" class="btn btn-accent"><i class="bi bi-folder-plus"></i> Nova Pasta</a>
+    </div>
+    {% endif %}
+  </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- moderniza a página de detalhamento de biblioteca com breadcrumb e cards
- exibe lista de pastas e grid de arquivos recentes
- adiciona estilos para grid de assets
- prepara rota para enviar assets à view

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68431be8ecf083328d6a673bcd6a8e08