### PR TITLE
Implement tag management features

### DIFF
--- a/arkiv_app/tag/forms.py
+++ b/arkiv_app/tag/forms.py
@@ -1,9 +1,29 @@
 from flask_wtf import FlaskForm
 from wtforms import StringField, SubmitField
-from wtforms.validators import DataRequired
+from wtforms.validators import DataRequired, ValidationError
+
+from ..models import Tag
+from ..utils import current_org_id
 
 
 class TagForm(FlaskForm):
-    name = StringField('Nome', validators=[DataRequired()])
-    color_hex = StringField('Cor')
-    submit = SubmitField('Salvar')
+    """Formulário para criação/edição de tags."""
+
+    name = StringField("Nome", validators=[DataRequired()])
+    color_hex = StringField("Cor")
+    submit = SubmitField("Salvar")
+
+    def __init__(self, original=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Tag instance being edited, for uniqueness validation
+        self.original = original
+
+    def validate_name(self, field):
+        org_id = current_org_id()
+        if org_id is None:
+            return
+        query = Tag.query.filter_by(org_id=org_id, name=field.data)
+        if self.original is not None:
+            query = query.filter(Tag.id != self.original.id)
+        if query.first():
+            raise ValidationError("Nome de tag j\u00e1 existe")

--- a/arkiv_app/templates/tag/form.html
+++ b/arkiv_app/templates/tag/form.html
@@ -4,7 +4,7 @@
 <form method="post" class="card guarded-form">
   {{ form.hidden_tag() }}
   <div class="field">{{ form.name.label }} {{ form.name(size=32, required=True) }}</div>
-  <div class="field">{{ form.color_hex.label }} {{ form.color_hex(size=10) }}</div>
+  <div class="field">{{ form.color_hex.label }} {{ form.color_hex(type='color') }}</div>
   <div class="d-flex gap-2">
     {{ form.submit(class_='btn btn-accent') }}
     <a href="{{ url_for('tag.list_tags') }}" class="btn btn-outline-secondary btn-cancel">Cancelar</a>

--- a/arkiv_app/templates/tag/list.html
+++ b/arkiv_app/templates/tag/list.html
@@ -1,20 +1,55 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1>Tags</h1>
-<a href="{{ url_for('tag.create_tag') }}" class="btn btn-accent mb-3"><i class="bi bi-plus-circle"></i> Nova Tag</a>
+<div class="d-flex justify-content-between align-items-center mb-4 flex-column flex-sm-row gap-3">
+  <h1 class="mb-0">Tags da Organização</h1>
+  <a href="{{ url_for('tag.create_tag') }}" class="btn btn-accent"><i class="bi bi-plus-circle"></i> Criar nova tag</a>
+</div>
+<form method="get" class="mb-4" role="search">
+  <div class="row g-2">
+    <div class="col">
+      <input type="search" class="form-control" name="q" value="{{ q }}" placeholder="Buscar tag por nome…" aria-label="Buscar tag">
+    </div>
+    <div class="col-auto">
+      <select name="color" class="form-select" aria-label="Filtrar cor">
+        <option value="">Todas as cores</option>
+        {% for c in colors %}
+        <option value="{{ c }}" {% if c == color %}selected{% endif %}>{{ c }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="col-auto">
+      <select name="sort" class="form-select" aria-label="Ordenar">
+        <option value="name" {% if sort != 'usage' %}selected{% endif %}>A-Z</option>
+        <option value="usage" {% if sort == 'usage' %}selected{% endif %}>Mais usadas</option>
+      </select>
+    </div>
+    <div class="col-auto">
+      <button type="submit" class="btn btn-outline-secondary"><i class="bi bi-search"></i></button>
+    </div>
+  </div>
+</form>
+{% if tags %}
 <ul class="list-group">
   {% for t in tags %}
+  {% set tag = t.instance %}
   <li class="list-group-item d-flex justify-content-between align-items-center">
-    <span>{{ t.name }}</span>
+    <div>
+      <span class="badge me-2" style="background-color: {{ tag.color_hex }}">{{ tag.name }}</span>
+      <span class="text-muted small">{{ t.asset_count }} assets</span>
+    </div>
     <div class="btn-group">
-      <a href="{{ url_for('tag.edit_tag', tag_id=t.id) }}" class="btn btn-outline-secondary btn-sm"><i class="bi bi-pencil"></i></a>
-      <form action="{{ url_for('tag.delete_tag', tag_id=t.id) }}" method="post" class="d-inline">
-        <button type="submit" class="btn btn-outline-danger btn-sm"><i class="bi bi-trash"></i></button>
+      <a href="{{ url_for('tag.edit_tag', tag_id=tag.id) }}" class="btn btn-outline-secondary btn-sm" aria-label="Editar"><i class="bi bi-pencil"></i></a>
+      <form action="{{ url_for('tag.delete_tag', tag_id=tag.id) }}" method="post" class="d-inline" onsubmit="return confirm('Remover tag?');">
+        <button type="submit" class="btn btn-outline-danger btn-sm" aria-label="Remover"><i class="bi bi-trash"></i></button>
       </form>
     </div>
   </li>
-  {% else %}
-  <li class="list-group-item">Nenhuma tag</li>
   {% endfor %}
 </ul>
+{% else %}
+<div class="text-center py-5">
+  <p class="lead">Nenhuma tag cadastrada ainda. Crie a primeira para organizar seus arquivos!</p>
+  <a href="{{ url_for('tag.create_tag') }}" class="btn btn-accent btn-lg"><i class="bi bi-plus-circle"></i> Criar tag</a>
+</div>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- improve `TagForm` with uniqueness validation
- add search, filter and sort for tags
- show asset counts and color badges in tag listing
- update tag forms to use color picker

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68431f0f32d48332b0e17e1e32780e47