### PR TITLE
Implement organization settings screen

### DIFF
--- a/arkiv_app/__init__.py
+++ b/arkiv_app/__init__.py
@@ -41,6 +41,7 @@ def create_app(config_name='development'):
     from .search import search_bp
     from .reports import reports_bp
     from .admin import admin_bp
+    from .organization import organization_bp
 
     app.register_blueprint(main_bp)
     app.register_blueprint(api_bp)
@@ -52,6 +53,7 @@ def create_app(config_name='development'):
     app.register_blueprint(search_bp)
     app.register_blueprint(reports_bp)
     app.register_blueprint(admin_bp)
+    app.register_blueprint(organization_bp)
     csrf.exempt(api_bp)
 
     @app.after_request

--- a/arkiv_app/organization/__init__.py
+++ b/arkiv_app/organization/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+organization_bp = Blueprint('organization', __name__, url_prefix='/org')
+
+from . import routes  # noqa: E402,F401

--- a/arkiv_app/organization/forms.py
+++ b/arkiv_app/organization/forms.py
@@ -1,0 +1,10 @@
+from flask_wtf import FlaskForm
+from wtforms import StringField, TextAreaField, SubmitField
+from wtforms.validators import DataRequired
+
+
+class OrganizationForm(FlaskForm):
+    name = StringField('Nome da Organização', validators=[DataRequired()])
+    description = TextAreaField('Descrição')
+    custom_domain = StringField('Domínio Personalizado')
+    submit = SubmitField('Salvar')

--- a/arkiv_app/organization/routes.py
+++ b/arkiv_app/organization/routes.py
@@ -1,0 +1,43 @@
+from flask import render_template, abort, redirect, url_for, flash
+from flask_login import login_required, current_user
+
+from ..extensions import db
+from ..models import Asset, Library
+from ..utils import current_org_id
+from .forms import OrganizationForm
+from . import organization_bp
+
+
+@organization_bp.route('/settings', methods=['GET', 'POST'])
+@login_required
+def settings():
+    membership = current_user.memberships[0] if current_user.memberships else None
+    if not membership or membership.role not in ('OWNER', 'MANAGER'):
+        abort(403)
+
+    org = membership.organization
+    form = OrganizationForm(name=org.name)
+
+    if form.validate_on_submit():
+        org.name = form.name.data
+        db.session.commit()
+        flash('Configurações salvas')
+        return redirect(url_for('organization.settings'))
+
+    used_storage = (
+        db.session.query(db.func.sum(Asset.size))
+        .join(Library)
+        .filter(Library.org_id == org.id)
+        .scalar()
+        or 0
+    )
+    quota = org.plan.storage_quota_gb * 1024 * 1024 * 1024
+
+    return render_template(
+        'organization/settings.html',
+        form=form,
+        org=org,
+        used_storage=used_storage,
+        quota=quota,
+        title='Configurações da Organização',
+    )

--- a/arkiv_app/templates/home.html
+++ b/arkiv_app/templates/home.html
@@ -50,7 +50,7 @@
     </a>
   </div>
   <div class="col-6 col-sm-4 col-md-2">
-    <a href="#" class="card quick-link shadow-soft h-100" aria-label="Configurações da Organização">
+    <a href="{{ url_for('organization.settings') }}" class="card quick-link shadow-soft h-100" aria-label="Configurações da Organização">
       <div class="card-body">
         <i class="bi bi-gear-fill display-6 text-accent"></i>
         <h6 class="mt-2 mb-0">Configurações</h6>

--- a/arkiv_app/templates/organization/settings.html
+++ b/arkiv_app/templates/organization/settings.html
@@ -1,0 +1,92 @@
+{% extends 'base.html' %}
+{% block breadcrumb %}
+<span class="text-muted">Org: {{ org.name }} &gt; Configurações</span>
+{% endblock %}
+{% block content %}
+<h1 class="mb-4">Configurações da Organização</h1>
+<div class="row">
+  <div class="col-md-3 mb-3">
+    <ul class="nav nav-pills flex-md-column gap-1" id="settingsTabs" role="tablist">
+      <li class="nav-item" role="presentation">
+        <button class="nav-link active" id="tab-profile-tab" data-bs-toggle="tab" data-bs-target="#tab-profile" type="button" role="tab">Perfil/Identidade</button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" id="tab-domain-tab" data-bs-toggle="tab" data-bs-target="#tab-domain" type="button" role="tab">Domínio personalizado</button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" id="tab-plan-tab" data-bs-toggle="tab" data-bs-target="#tab-plan" type="button" role="tab">Plano e Faturamento</button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" id="tab-members-tab" data-bs-toggle="tab" data-bs-target="#tab-members" type="button" role="tab">Gerenciar membros</button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" id="tab-storage-tab" data-bs-toggle="tab" data-bs-target="#tab-storage" type="button" role="tab">Quota de armazenamento</button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" id="tab-security-tab" data-bs-toggle="tab" data-bs-target="#tab-security" type="button" role="tab">Segurança</button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" id="tab-integrations-tab" data-bs-toggle="tab" data-bs-target="#tab-integrations" type="button" role="tab">Integrações</button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link text-danger" id="tab-danger-tab" data-bs-toggle="tab" data-bs-target="#tab-danger" type="button" role="tab">Ações perigosas</button>
+      </li>
+    </ul>
+  </div>
+  <div class="col-md-9">
+    <div class="tab-content" id="settingsContent">
+      <div class="tab-pane fade show active" id="tab-profile" role="tabpanel">
+        <form method="post" class="card guarded-form">
+          {{ form.hidden_tag() }}
+          <div class="field mb-3">{{ form.name.label }} {{ form.name(class_='form-control', required=True) }}</div>
+          <div class="field mb-3">{{ form.description.label }} {{ form.description(class_='form-control', rows=3) }}</div>
+          <div class="field mb-3">{{ form.custom_domain.label }} {{ form.custom_domain(class_='form-control') }}
+            <small class="text-muted">Crie um registro CNAME para org.arkiv.app</small>
+          </div>
+          <div class="d-flex gap-2">
+            {{ form.submit(class_='btn btn-accent') }}
+            <button type="reset" class="btn btn-outline-secondary btn-cancel">Cancelar</button>
+          </div>
+        </form>
+      </div>
+      <div class="tab-pane fade" id="tab-domain" role="tabpanel">
+        <p>Configure seu domínio personalizado apontando para <code>org.arkiv.app</code>.</p>
+      </div>
+      <div class="tab-pane fade" id="tab-plan" role="tabpanel">
+        <div class="card p-3">
+          <h5 class="mb-2">Plano atual: {{ org.plan.name }}</h5>
+          <p class="mb-3">Armazenamento incluso: {{ org.plan.storage_quota_gb }}GB</p>
+          <a href="#" class="btn btn-outline-accent">Alterar plano</a>
+        </div>
+      </div>
+      <div class="tab-pane fade" id="tab-members" role="tabpanel">
+        <p>{{ org.members|length }} membros cadastrados.</p>
+        <a href="#" class="btn btn-outline-accent">Gerenciar membros</a>
+      </div>
+      <div class="tab-pane fade" id="tab-storage" role="tabpanel">
+        <p>{{ (used_storage/1024/1024/1024)|round(2) }}GB de {{ org.plan.storage_quota_gb }}GB usados</p>
+        <div class="progress mb-2" style="height: 20px;">
+          <div class="progress-bar" role="progressbar" style="width: {{ (used_storage/quota*100)|round(2) }}%" aria-valuenow="{{ (used_storage/quota*100)|round(0) }}" aria-valuemin="0" aria-valuemax="100"></div>
+        </div>
+        <a href="#" class="btn btn-outline-accent">Upgrade de espaço</a>
+      </div>
+      <div class="tab-pane fade" id="tab-security" role="tabpanel">
+        <p>2FA {{ 'ativado' if current_user.mfa_enabled else 'desativado' }}.</p>
+        <p>Política de senha: mínimo 8 caracteres.</p>
+      </div>
+      <div class="tab-pane fade" id="tab-integrations" role="tabpanel">
+        <p>Nenhuma integração configurada.</p>
+      </div>
+      <div class="tab-pane fade" id="tab-danger" role="tabpanel">
+        <div class="card p-3">
+          <p class="text-danger">Estas ações são irreversíveis.</p>
+          <button class="btn btn-outline-danger">Excluir organização</button>
+          <button class="btn btn-outline-warning ms-2">Exportar dados</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% from 'components/form_dirty_guard.html' import guard %}
+{{ guard() }}
+{% endblock %}


### PR DESCRIPTION
## Summary
- add new `organization` blueprint with forms and routes
- register blueprint in application factory
- create organization settings template with tabs and placeholders
- link to organization settings from home

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684321c43464833282b24fcffa8434e0