### PR TITLE
Improve navbar layout and search UX

### DIFF
--- a/arkiv_app/search/routes.py
+++ b/arkiv_app/search/routes.py
@@ -11,6 +11,8 @@ from . import search_bp
 @login_required
 def search_page():
     """Renderiza a tela de busca global."""
+    if request.headers.get('HX-Request'):
+        return render_template('search/_global_partial.html')
     return render_template('search/global.html', title='Busca Global')
 
 

--- a/arkiv_app/static/css/style.css
+++ b/arkiv_app/static/css/style.css
@@ -193,6 +193,12 @@ button:hover, .btn:hover {
   }
 }
 
+@media (max-width: 768px) {
+  .floating-container {
+    margin-top: 70px;
+  }
+}
+
 .skeleton-card {
   background: linear-gradient(90deg, var(--card-bg) 25%, #e0e0e0 50%, var(--card-bg) 75%);
   background-size: 200% 100%;
@@ -217,6 +223,19 @@ button:hover, .btn:hover {
   background: var(--card-bg);
   box-shadow: 0 4px 12px rgba(0,0,0,0.1);
   z-index: 1030;
+}
+
+@media (max-width: 768px) {
+  body {
+    padding-top: 70px;
+  }
+  .navbar-floating {
+    width: 100%;
+    left: 0;
+    transform: none;
+    border-radius: 0;
+    top: 0;
+  }
 }
 
 .avatar-frame {

--- a/arkiv_app/static/js/global_search.js
+++ b/arkiv_app/static/js/global_search.js
@@ -1,9 +1,11 @@
-document.addEventListener('DOMContentLoaded', () => {
+function initGlobalSearch() {
   const input = document.querySelector('#globalSearchInput');
   const resultsEl = document.querySelector('#results');
   const noResultsEl = document.querySelector('#noResults');
   const filtersForm = document.querySelector('#filtersForm');
   const clearBtn = document.querySelector('#clearSearch');
+
+  if (!input || !resultsEl || !filtersForm) return;
 
   function fetchResults() {
     const params = new URLSearchParams(new FormData(filtersForm));
@@ -41,4 +43,10 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   fetchResults();
-});
+}
+
+if (document.readyState !== 'loading') {
+  initGlobalSearch();
+} else {
+  document.addEventListener('DOMContentLoaded', initGlobalSearch);
+}

--- a/arkiv_app/templates/components/navbar.html
+++ b/arkiv_app/templates/components/navbar.html
@@ -1,11 +1,6 @@
 <nav class="navbar navbar-floating" aria-label="Barra de navegação principal">
   <div class="container-fluid d-flex align-items-center justify-content-between gap-3">
-    <div class="d-flex align-items-center gap-2">
-      <div class="avatar-frame" data-bs-toggle="modal" data-bs-target="#userModal">
-        <img src="{{ url_for('static', filename='img/avatar.svg') }}" alt="{{ current_user.name }}" loading="lazy">
-      </div>
-      <a class="navbar-brand" href="{{ url_for('main.index') }}">Arkiv</a>
-    </div>
+    <a class="navbar-brand" href="{{ url_for('main.index') }}">Arkiv</a>
     {% if not login_page %}
     <form class="flex-grow-1 mx-3" role="search" hx-get="/search" hx-trigger="keyup changed delay:300ms" hx-target="#content" hx-push-url="true">
       <input class="form-control" type="search" placeholder="Buscar" name="q" aria-label="Buscar">
@@ -13,9 +8,11 @@
     {% endif %}
   <div class="d-flex align-items-center gap-2">
     <button class="btn btn-link theme-toggle p-0" onclick="toggleTheme()" aria-label="Alternar tema" aria-pressed="false"><i class="bi bi-moon-fill"></i></button>
+    {% if current_user.is_authenticated %}
     <div class="avatar-frame" data-bs-toggle="modal" data-bs-target="#userModal">
       <img src="{{ url_for('static', filename='img/avatar.svg') }}" alt="{{ current_user.name }}" loading="lazy">
     </div>
+    {% endif %}
   </div>
   </div>
 </nav>

--- a/arkiv_app/templates/search/_global_partial.html
+++ b/arkiv_app/templates/search/_global_partial.html
@@ -1,0 +1,27 @@
+<div class="row g-4">
+  <div class="col-lg-3 order-lg-1">
+    <div class="card shadow-soft">
+      <form id="filtersForm" class="d-flex flex-column gap-3">
+        <div>
+          <label class="form-label">Tipo</label>
+          <select class="form-select" name="type">
+            <option value="">Todos</option>
+            <option value="asset">Imagem/Arquivo</option>
+            <option value="folder">Pasta</option>
+            <option value="library">Biblioteca</option>
+          </select>
+        </div>
+      </form>
+    </div>
+  </div>
+  <div class="col-lg-9 order-lg-0">
+    <div class="input-group input-group-lg mb-3">
+      <span class="input-group-text"><i class="bi bi-search"></i></span>
+      <input id="globalSearchInput" class="form-control" type="search" placeholder="Buscar por nome, tag, tipo, usuário..." aria-label="Buscar">
+      <button class="btn btn-outline-secondary" type="button" id="clearSearch" aria-label="Limpar"><i class="bi bi-x-lg"></i></button>
+    </div>
+    <div id="results" class="row g-3"></div>
+    <div id="noResults" class="text-center text-muted mt-4 d-none">Nenhum resultado encontrado</div>
+  </div>
+</div>
+<script src="{{ url_for('static', filename='js/global_search.js') }}"></script>

--- a/arkiv_app/templates/search/global.html
+++ b/arkiv_app/templates/search/global.html
@@ -1,31 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
-<div class="row g-4">
-  <div class="col-lg-3 order-lg-1">
-    <div class="card shadow-soft">
-      <form id="filtersForm" class="d-flex flex-column gap-3">
-        <div>
-          <label class="form-label">Tipo</label>
-          <select class="form-select" name="type">
-            <option value="">Todos</option>
-            <option value="asset">Imagem/Arquivo</option>
-            <option value="folder">Pasta</option>
-            <option value="library">Biblioteca</option>
-          </select>
-        </div>
-      </form>
-    </div>
-  </div>
-  <div class="col-lg-9 order-lg-0">
-    <div class="input-group input-group-lg mb-3">
-      <span class="input-group-text"><i class="bi bi-search"></i></span>
-      <input id="globalSearchInput" class="form-control" type="search" placeholder="Buscar por nome, tag, tipo, usuário..." aria-label="Buscar">
-      <button class="btn btn-outline-secondary" type="button" id="clearSearch" aria-label="Limpar"><i class="bi bi-x-lg"></i></button>
-    </div>
-    <div id="results" class="row g-3"></div>
-    <div id="noResults" class="text-center text-muted mt-4 d-none">Nenhum resultado encontrado</div>
-  </div>
-</div>
+{% include 'search/_global_partial.html' %}
 {% endblock %}
 {% block scripts %}
 <script src="{{ url_for('static', filename='js/global_search.js') }}"></script>


### PR DESCRIPTION
## Summary
- declutter navbar and only show avatar when logged in
- avoid navbar duplication for HTMX search results
- create partial search template for htmx
- adjust responsive navbar and page spacing
- make global search JS reinitializable

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684336e663008332b2cfd0494befa672