### PR TITLE
Add trash management screen

### DIFF
--- a/arkiv_app/__init__.py
+++ b/arkiv_app/__init__.py
@@ -43,6 +43,7 @@ def create_app(config_name='development'):
     from .reports import reports_bp
     from .admin import admin_bp
     from .organization import organization_bp
+    from .trash import trash_bp
 
     app.register_blueprint(main_bp)
     app.register_blueprint(api_bp)
@@ -56,6 +57,7 @@ def create_app(config_name='development'):
     app.register_blueprint(reports_bp)
     app.register_blueprint(admin_bp)
     app.register_blueprint(organization_bp)
+    app.register_blueprint(trash_bp)
     csrf.exempt(api_bp)
 
     @app.after_request

--- a/arkiv_app/config.py
+++ b/arkiv_app/config.py
@@ -15,6 +15,7 @@ class Config:
     THUMB_FOLDER = os.environ.get('THUMB_FOLDER', 'instance/thumbnails')
     LOG_LEVEL = os.environ.get('LOG_LEVEL', 'INFO')
     SENTRY_DSN = os.environ.get('SENTRY_DSN')
+    TRASH_RETENTION_DAYS = int(os.environ.get('TRASH_RETENTION_DAYS', 30))
 
 class DevelopmentConfig(Config):
     DEBUG = True

--- a/arkiv_app/templates/trash/list.html
+++ b/arkiv_app/templates/trash/list.html
@@ -1,0 +1,59 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="d-flex align-items-center gap-2 mb-4">
+  <i class="bi bi-trash3-fill fs-2 text-danger"></i>
+  <h1 class="m-0">Lixeira</h1>
+</div>
+<div class="alert alert-info">
+  Itens permanecem {{ retention_days }} dias antes da exclusão definitiva.
+</div>
+{% if assets %}
+<table class="table table-hover align-middle">
+  <thead>
+    <tr>
+      <th>Nome</th>
+      <th>Biblioteca/Pasta</th>
+      <th>Deletado por</th>
+      <th>Data</th>
+      <th>Expira em</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for a in assets %}
+    <tr>
+      <td>
+        {% if a.mime.startswith('image') %}
+        <img src="{{ url_for('asset.asset_file', asset_id=a.id) }}" alt="" width="40" class="me-2 rounded">
+        {% endif %}
+        {{ a.filename_orig }}
+      </td>
+      <td>{{ a.folder.library.name }} / {{ a.folder.name }}</td>
+      <td>{{ a.uploader.name }}</td>
+      <td>{{ a.deleted_at.strftime('%d/%m/%Y') }}</td>
+      <td>
+        {% set days_left = retention_days - (now - a.deleted_at).days %}
+        {% if days_left <= 3 %}
+        <span class="text-danger fw-semibold">Expira em {{ days_left }} dias!</span>
+        {% else %}
+        {{ days_left }} dias
+        {% endif %}
+      </td>
+      <td class="text-end">
+        <form action="{{ url_for('trash.restore_asset', asset_id=a.id) }}" method="post" class="d-inline">
+          <button class="btn btn-outline-success btn-sm" title="Restaurar"><i class="bi bi-arrow-counterclockwise"></i></button>
+        </form>
+        <form action="{{ url_for('trash.purge_asset', asset_id=a.id) }}" method="post" class="d-inline" onsubmit="return confirm('Excluir permanentemente?');">
+          <button class="btn btn-outline-danger btn-sm" title="Excluir definitivamente"><i class="bi bi-trash"></i></button>
+        </form>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<div class="text-center p-5">
+  <p class="fs-4">Nada na lixeira! Seus arquivos estão todos em dia.</p>
+</div>
+{% endif %}
+{% endblock %}

--- a/arkiv_app/trash/__init__.py
+++ b/arkiv_app/trash/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+trash_bp = Blueprint('trash', __name__, url_prefix='/trash')
+
+from . import routes  # noqa

--- a/arkiv_app/trash/routes.py
+++ b/arkiv_app/trash/routes.py
@@ -1,0 +1,72 @@
+import os
+from datetime import datetime
+from flask import render_template, redirect, url_for, flash, current_app
+from flask_login import login_required, current_user
+
+from ..extensions import db
+from ..models import Asset, Library
+from ..utils import current_org_id
+from ..utils.audit import record_audit
+from . import trash_bp
+
+
+@trash_bp.route('/')
+@login_required
+def list_trash():
+    org_id = current_org_id()
+    assets = (
+        Asset.query
+        .join(Library)
+        .filter(Library.org_id == org_id, Asset.deleted_at.isnot(None))
+        .order_by(Asset.deleted_at.desc())
+        .all()
+    )
+    retention_days = current_app.config.get('TRASH_RETENTION_DAYS', 30)
+    now = datetime.utcnow()
+    return render_template(
+        'trash/list.html',
+        assets=assets,
+        retention_days=retention_days,
+        now=now,
+        title='Lixeira'
+    )
+
+
+@trash_bp.route('/assets/<int:asset_id>/restore', methods=['POST'])
+@login_required
+def restore_asset(asset_id):
+    asset = Asset.query.get_or_404(asset_id)
+    org_id = current_org_id()
+    if asset.folder.library.org_id != org_id or not asset.deleted_at:
+        flash('Ação inválida')
+        return redirect(url_for('trash.list_trash'))
+    asset.deleted_at = None
+    db.session.commit()
+    record_audit('restore', 'asset', asset.id, user_id=current_user.id, org_id=org_id)
+    flash('Arquivo restaurado!')
+    return redirect(url_for('trash.list_trash'))
+
+
+@trash_bp.route('/assets/<int:asset_id>/purge', methods=['POST'])
+@login_required
+def purge_asset(asset_id):
+    asset = Asset.query.get_or_404(asset_id)
+    org_id = current_org_id()
+    if asset.folder.library.org_id != org_id or not asset.deleted_at:
+        flash('Ação inválida')
+        return redirect(url_for('trash.list_trash'))
+    upload_path = current_app.config['UPLOAD_FOLDER']
+    thumb_path = current_app.config['THUMB_FOLDER']
+    try:
+        os.remove(os.path.join(upload_path, asset.filename_storage))
+    except FileNotFoundError:
+        pass
+    try:
+        os.remove(os.path.join(thumb_path, asset.filename_storage))
+    except FileNotFoundError:
+        pass
+    db.session.delete(asset)
+    db.session.commit()
+    record_audit('purge', 'asset', asset.id, user_id=current_user.id, org_id=org_id)
+    flash('Arquivo excluído permanentemente!')
+    return redirect(url_for('trash.list_trash'))

--- a/tests/test_trash.py
+++ b/tests/test_trash.py
@@ -1,0 +1,55 @@
+from datetime import datetime
+from arkiv_app.extensions import db
+from arkiv_app.models import Library, Folder, Asset
+
+
+def login(client):
+    client.post('/login', data={'email': 'test@example.com', 'password': 'test'}, follow_redirects=True)
+
+
+def setup_asset(app):
+    with app.app_context():
+        lib = Library(org_id=1, name='Lib', description='d')
+        folder = Folder(name='F', library=lib)
+        asset = Asset(
+            library=lib,
+            folder=folder,
+            uploader_id=1,
+            filename_orig='del.png',
+            filename_storage='del.png',
+            mime='image/png',
+            size=1,
+            checksum_sha256='x'
+        )
+        db.session.add_all([lib, folder, asset])
+        db.session.commit()
+        return asset.id
+
+
+def test_trash_view_and_restore(client, app):
+    login(client)
+    asset_id = setup_asset(app)
+    with app.app_context():
+        asset = Asset.query.get(asset_id)
+        asset.deleted_at = datetime.utcnow()
+        db.session.commit()
+    res = client.get('/trash/')
+    assert res.status_code == 200
+    assert b'del.png' in res.data
+    res = client.post(f'/trash/assets/{asset_id}/restore', follow_redirects=True)
+    assert b'Arquivo restaurado' in res.data
+    with app.app_context():
+        assert Asset.query.get(asset_id).deleted_at is None
+
+
+def test_trash_purge(client, app):
+    login(client)
+    asset_id = setup_asset(app)
+    with app.app_context():
+        asset = Asset.query.get(asset_id)
+        asset.deleted_at = datetime.utcnow()
+        db.session.commit()
+    res = client.post(f'/trash/assets/{asset_id}/purge', follow_redirects=True)
+    assert b'exclu\xc3\xaddo permanentemente' in res.data
+    with app.app_context():
+        assert Asset.query.get(asset_id) is None


### PR DESCRIPTION
## Summary
- add trash blueprint for listing deleted files
- implement restore and purge actions
- register trash blueprint and retention config
- add basic UI for trash screen
- test trash routes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684338ece298833285bd18b9f51d0e98