### PR TITLE
Implement role based access control

### DIFF
--- a/arkiv_app/asset/routes.py
+++ b/arkiv_app/asset/routes.py
@@ -16,6 +16,7 @@ from flask_login import login_required, current_user
 from ..extensions import db, limiter
 from ..models import Asset, Folder, Library
 from ..utils.audit import record_audit
+from ..utils import role_required
 from . import asset_bp
 from .forms import AssetUploadForm
 from .tasks import generate_thumbnail, perform_ocr
@@ -24,6 +25,7 @@ from .tasks import generate_thumbnail, perform_ocr
 @asset_bp.route("/folders/<int:folder_id>/assets", methods=["GET", "POST"])
 @login_required
 @limiter.limit("20 per minute")
+@role_required("OWNER", "MANAGER", "EDITOR", "CONTRIBUTOR")
 def upload_asset(folder_id):
     folder = Folder.query.get_or_404(folder_id)
     form = AssetUploadForm()
@@ -105,6 +107,7 @@ def asset_file(asset_id):
 
 @asset_bp.route("/assets/<int:asset_id>/delete", methods=["POST"])
 @login_required
+@role_required("OWNER", "MANAGER", "EDITOR")
 def delete_asset(asset_id):
     asset = Asset.query.get_or_404(asset_id)
     asset.deleted_at = datetime.utcnow()

--- a/arkiv_app/folder/routes.py
+++ b/arkiv_app/folder/routes.py
@@ -1,7 +1,7 @@
 from flask import render_template, redirect, url_for, flash, request
 from flask_login import login_required, current_user
 
-from ..utils import current_org_id
+from ..utils import current_org_id, role_required
 
 from ..extensions import db
 from ..models import Library, Folder
@@ -23,6 +23,7 @@ def _populate_form_choices(form, libs):
 
 @folder_bp.route("/folders/create", methods=["GET", "POST"])
 @login_required
+@role_required("OWNER", "MANAGER", "EDITOR", "CONTRIBUTOR")
 def create_folder():
     form = FolderForm()
     org_id = current_org_id()
@@ -58,6 +59,7 @@ def create_folder():
 
 @folder_bp.route("/folders/<int:folder_id>/edit", methods=["GET", "POST"])
 @login_required
+@role_required("OWNER", "MANAGER", "EDITOR")
 def edit_folder(folder_id):
     folder = Folder.query.get_or_404(folder_id)
     form = FolderForm(obj=folder)
@@ -86,6 +88,7 @@ def edit_folder(folder_id):
 
 @folder_bp.route("/folders/<int:folder_id>/delete", methods=["POST"])
 @login_required
+@role_required("OWNER", "MANAGER", "EDITOR")
 def delete_folder(folder_id):
     folder = Folder.query.get_or_404(folder_id)
     db.session.delete(folder)

--- a/arkiv_app/library/routes.py
+++ b/arkiv_app/library/routes.py
@@ -1,7 +1,7 @@
 from flask import render_template, redirect, url_for, flash, request
 from flask_login import login_required, current_user
 
-from ..utils import current_org_id
+from ..utils import current_org_id, role_required
 
 from ..extensions import db
 from ..utils.audit import record_audit
@@ -83,6 +83,7 @@ def show_library(lib_id):
 
 @library_bp.route("/libraries/create", methods=["GET", "POST"])
 @login_required
+@role_required("OWNER", "MANAGER", "EDITOR")
 def create_library():
     form = LibraryForm()
     if form.validate_on_submit():
@@ -102,6 +103,7 @@ def create_library():
 
 @library_bp.route("/libraries/<int:lib_id>/edit", methods=["GET", "POST"])
 @login_required
+@role_required("OWNER", "MANAGER", "EDITOR")
 def edit_library(lib_id):
     lib = Library.query.get_or_404(lib_id)
     form = LibraryForm(obj=lib)
@@ -123,6 +125,7 @@ def edit_library(lib_id):
 
 @library_bp.route("/libraries/<int:lib_id>/delete", methods=["POST"])
 @login_required
+@role_required("OWNER", "MANAGER")
 def delete_library(lib_id):
     lib = Library.query.get_or_404(lib_id)
     db.session.delete(lib)

--- a/arkiv_app/organization/routes.py
+++ b/arkiv_app/organization/routes.py
@@ -4,17 +4,16 @@ from flask_login import login_required, current_user
 
 from ..extensions import db
 from ..models import Asset, Library, User, Membership
-from ..utils import current_org_id
+from ..utils import current_org_id, role_required
 from .forms import OrganizationForm, InviteUserForm
 from . import organization_bp
 
 
 @organization_bp.route('/settings', methods=['GET', 'POST'])
 @login_required
+@role_required('OWNER', 'MANAGER')
 def settings():
     membership = current_user.memberships[0] if current_user.memberships else None
-    if not membership or membership.role not in ('OWNER', 'MANAGER'):
-        abort(403)
 
     org = membership.organization
     form = OrganizationForm(name=org.name)
@@ -46,10 +45,9 @@ def settings():
 
 @organization_bp.route('/members', methods=['GET', 'POST'])
 @login_required
+@role_required('OWNER', 'MANAGER')
 def members():
     membership = current_user.memberships[0] if current_user.memberships else None
-    if not membership or membership.role not in ('OWNER', 'MANAGER'):
-        abort(403)
 
     org = membership.organization
     invite_form = InviteUserForm()
@@ -103,10 +101,9 @@ def members():
 
 @organization_bp.route('/members/<int:user_id>/role', methods=['POST'])
 @login_required
+@role_required('OWNER', 'MANAGER')
 def update_member_role(user_id):
     membership = current_user.memberships[0] if current_user.memberships else None
-    if not membership or membership.role not in ('OWNER', 'MANAGER'):
-        abort(403)
     org = membership.organization
     new_role = request.form.get('role')
     mem = Membership.query.filter_by(user_id=user_id, org_id=org.id).first_or_404()
@@ -121,10 +118,9 @@ def update_member_role(user_id):
 
 @organization_bp.route('/members/<int:user_id>/remove', methods=['POST'])
 @login_required
+@role_required('OWNER', 'MANAGER')
 def remove_member(user_id):
     membership = current_user.memberships[0] if current_user.memberships else None
-    if not membership or membership.role not in ('OWNER', 'MANAGER'):
-        abort(403)
     org = membership.organization
     mem = Membership.query.filter_by(user_id=user_id, org_id=org.id).first_or_404()
     if mem.role == 'OWNER':

--- a/arkiv_app/utils/__init__.py
+++ b/arkiv_app/utils/__init__.py
@@ -1,4 +1,7 @@
+from functools import wraps
+from flask import abort
 from flask_login import current_user
+from ..extensions import login_manager
 
 
 def current_org_id():
@@ -6,3 +9,28 @@ def current_org_id():
     if current_user.is_authenticated and current_user.memberships:
         return current_user.memberships[0].org_id
     return None
+
+
+def role_required(*roles):
+    """Ensure the current user has one of the given roles.
+
+    Usage::
+
+        @role_required("OWNER", "MANAGER")
+        def view():
+            ...
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            if not current_user.is_authenticated:
+                return login_manager.unauthorized()
+            membership = current_user.memberships[0] if current_user.memberships else None
+            if not membership or membership.role not in roles:
+                abort(403)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
## Summary
- add `role_required` decorator
- secure library, folder, asset and organization management routes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68433aa622d48332a4d043bb48cc5f0c