### PR TITLE
feat(ui): refactor layout, modals and breadcrumb

### DIFF
--- a/arkiv_app/static/css/forms.css
+++ b/arkiv_app/static/css/forms.css
@@ -1,0 +1,21 @@
+/* Form refinements */
+label {
+  font-weight: 500;
+  margin-bottom: 0.25rem;
+}
+input,
+select,
+textarea {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+  background-color: var(--bg-color);
+}
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(40, 160, 176, 0.35);
+}

--- a/arkiv_app/static/css/reset-overrides.css
+++ b/arkiv_app/static/css/reset-overrides.css
@@ -1,0 +1,18 @@
+/* Normalize elements reset by default */
+ul {
+  list-style: disc inside;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin-bottom: 1rem;
+}
+
+hr {
+  margin: 2rem 0;
+  border-color: #e5e5e5;
+}

--- a/arkiv_app/static/css/style.css
+++ b/arkiv_app/static/css/style.css
@@ -11,7 +11,10 @@
   --w-normal: 400;
   --w-medium: 500;
   --w-semibold: 600;
-  --navbar-height: 64px; /* ⇠ altura real da navbar */
+  --navbar-height: 64px; /* altura real da navbar */
+  --z-navbar: 1050;
+  --z-modal: 1060;
+  --z-tooltip: 1070;
 }
 
 [data-theme="dark"] {
@@ -32,8 +35,6 @@ body {
   color: var(--text-color);
   background: var(--bg-color);
   line-height: 1.5;
-  /* reserva espaço real p/ navbar, ajustável por var */
-  padding-top: var(--navbar-height);
 }
 
 /* ---------- Links & Botões ---------- */
@@ -94,7 +95,7 @@ button:hover,
   background: var(--card-bg);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   border-radius: 12px;
-  z-index: 1055; /* maior que modal-backdrop (z-index:1050) */
+  z-index: var(--z-navbar); /* maior que modal-backdrop */
 }
 
 /* Agrupamentos internos */
@@ -147,7 +148,7 @@ button:hover,
   -webkit-backdrop-filter: blur(10px);
   max-width: 1200px;
   width: 100%;
-  margin: 1rem auto;
+  margin: calc(var(--navbar-height) + 1rem) auto 1rem;
   padding: 2rem;
   border-radius: 12px;
   box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08);
@@ -227,16 +228,42 @@ ul li::before {
   color: var(--accent);
 }
 
+nav[aria-label="breadcrumb"] {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+nav[aria-label="breadcrumb"] ol {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0;
+  padding: 0;
+}
+nav[aria-label="breadcrumb"] ol li {
+  display: flex;
+  align-items: center;
+}
+nav[aria-label="breadcrumb"] ol li + li::before {
+  content: "\203A"; /* › */
+  margin: 0 0.25rem;
+  color: var(--text-color);
+}
+
 /* ---------- Modal ---------- */
 .modal,
 .user-modal {
-  z-index: 1060; /* acima da navbar (1055) */
+  z-index: var(--z-modal);
 }
 .user-modal .modal-content {
   background: var(--card-bg);
   border-radius: 12px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   padding: 1.5rem;
+}
+.user-modal .modal-body {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
 }
 
 /* ---------- Skeleton ---------- */
@@ -306,7 +333,7 @@ ul li::before {
   }
   .floating-container {
     padding: 1rem;
-    margin: var(--navbar-height) auto 0;
+    margin: calc(var(--navbar-height) + 0.5rem) auto 0;
   }
 }
 @media (max-width: 576px) {

--- a/arkiv_app/static/js/user-modal.js
+++ b/arkiv_app/static/js/user-modal.js
@@ -1,0 +1,13 @@
+ document.addEventListener('DOMContentLoaded', () => {
+   const modalEl = document.getElementById('userModal');
+   if (!modalEl) return;
+   const bsModal = new bootstrap.Modal(modalEl);
+   document.querySelectorAll('[data-bs-target="#userModal"]').forEach((el) => {
+     el.addEventListener('click', (ev) => {
+       ev.preventDefault();
+       if (!modalEl.classList.contains('show')) {
+         bsModal.show();
+       }
+     });
+   });
+ });

--- a/arkiv_app/templates/base.html
+++ b/arkiv_app/templates/base.html
@@ -9,19 +9,19 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/forms.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/reset-overrides.css') }}">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   {% block head %}{% endblock %}
 </head>
 <body>
   {% include 'components/navbar.html' %}
-  {% if not login_page %}
-  <div class="container mt-3 d-flex align-items-center" id="breadcrumb">
-    <a href="{{ request.referrer or url_for('main.index') }}" class="btn btn-link p-0 me-2" onclick="if (history.length > 1) { history.back(); return false; }"><i class="bi bi-arrow-left"></i> Voltar</a>
-    {% block breadcrumb %}{% endblock %}
-  </div>
-  {% endif %}
   <main id="content" class="py-5">
     <div class="floating-container container-fluid">
+      {% if not login_page %}
+      <a href="{{ request.referrer or url_for('main.index') }}" class="btn btn-outline-accent back-btn mb-3" onclick="if (history.length > 1) { history.back(); return false; }">Voltar</a>
+      {% block breadcrumb %}{% endblock %}
+      {% endif %}
       {% with messages = get_flashed_messages() %}
         {% if messages %}
         <ul class="flash">
@@ -37,6 +37,7 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script src="{{ url_for('static', filename='js/theme.js') }}"></script>
   <script src="{{ url_for('static', filename='js/main.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/user-modal.js') }}"></script>
   {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/arkiv_app/templates/components/navbar.html
+++ b/arkiv_app/templates/components/navbar.html
@@ -19,8 +19,8 @@
 
 <div class="modal fade user-modal" id="userModal" tabindex="-1" aria-labelledby="userModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered">
-    <div class="modal-content rounded-md">
-      <div class="modal-body d-flex flex-column gap-3 align-items-stretch" id="userModalLabel">
+    <div class="modal-content">
+      <div class="modal-body" id="userModalLabel">
         <a href="#" class="btn btn-accent">Configurações do Perfil</a>
         <a href="{{ url_for('auth.logout') }}" class="btn btn-outline-danger btn-logout">Logout</a>
       </div>


### PR DESCRIPTION
## Summary
- refine CSS variables for z-index tokens
- remove body padding and offset floating container below navbar
- add custom form styles and reset overrides
- redesign user modal and avoid phantom display
- inject back button inside floating container
- load new assets and script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684342d2a33c83329b459fae9b5607d9