### PR TITLE
Fix modal initialization and styles

### DIFF
--- a/arkiv_app/static/css/style.css
+++ b/arkiv_app/static/css/style.css
@@ -262,17 +262,16 @@ nav[aria-label="breadcrumb"] ol li + li::before {
 }
 
 /* ---------- Modal ---------- */
-.modal,
-.user-modal {
+.modal {
   z-index: var(--z-modal);
 }
-.user-modal .modal-content {
+.modal-content {
   background: var(--card-bg);
   border-radius: 12px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.12);
   padding: 1.5rem;
 }
-.user-modal .modal-body {
+.modal-footer {
   display: flex;
   justify-content: flex-end;
   gap: 0.5rem;

--- a/arkiv_app/static/js/user-modal.js
+++ b/arkiv_app/static/js/user-modal.js
@@ -1,13 +1,11 @@
- document.addEventListener('DOMContentLoaded', () => {
-   const modalEl = document.getElementById('userModal');
-   if (!modalEl) return;
-   const bsModal = new bootstrap.Modal(modalEl);
-   document.querySelectorAll('[data-bs-target="#userModal"]').forEach((el) => {
-     el.addEventListener('click', (ev) => {
-       ev.preventDefault();
-       if (!modalEl.classList.contains('show')) {
-         bsModal.show();
-       }
-     });
-   });
- });
+document.addEventListener('DOMContentLoaded', () => {
+  const modalEl = document.getElementById('userModal');
+  if (!modalEl) return;
+  document.querySelectorAll('[data-bs-target="#userModal"]').forEach((el) => {
+    el.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      const bsModal = bootstrap.Modal.getOrCreateInstance(modalEl);
+      bsModal.show();
+    });
+  });
+});

--- a/arkiv_app/templates/components/navbar.html
+++ b/arkiv_app/templates/components/navbar.html
@@ -32,8 +32,10 @@
 <div class="modal fade user-modal" id="userModal" tabindex="-1" aria-labelledby="userModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
-      <div class="modal-body" id="userModalLabel">
+      <div class="modal-body text-center" id="userModalLabel">
         <a href="#" class="btn btn-accent">Configurações do Perfil</a>
+      </div>
+      <div class="modal-footer">
         <a href="{{ url_for('auth.logout') }}" class="btn btn-outline-danger btn-logout">Logout</a>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- refactor modal initialization to only create on user click
- redesign modal footer and content styles
- adjust user menu modal markup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68435591dfbc833285afcf0c63da0e40