### PR TITLE
Add horizontal breadcrumb component

### DIFF
--- a/arkiv_app/static/css/style.css
+++ b/arkiv_app/static/css/style.css
@@ -243,11 +243,12 @@ ul li::before {
 nav[aria-label="breadcrumb"] {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
 }
 nav[aria-label="breadcrumb"] ol {
   display: flex;
+  align-items: center;
   gap: 0.5rem;
+  flex-wrap: wrap;
   margin-bottom: 0;
   padding: 0;
 }
@@ -255,10 +256,13 @@ nav[aria-label="breadcrumb"] ol li {
   display: flex;
   align-items: center;
 }
-nav[aria-label="breadcrumb"] ol li + li::before {
+nav[aria-label="breadcrumb"] .breadcrumb-item + .breadcrumb-item::before {
   content: "\203A"; /* › */
   margin: 0 0.25rem;
-  color: var(--text-color);
+  color: #6c757d;
+}
+nav[aria-label="breadcrumb"] .breadcrumb-item.active {
+  font-weight: var(--w-semibold);
 }
 
 /* ---------- Modal ---------- */

--- a/arkiv_app/templates/asset/detail.html
+++ b/arkiv_app/templates/asset/detail.html
@@ -1,13 +1,12 @@
 {% extends 'base.html' %}
+{% import 'components/breadcrumb.html' as breadcrumb %}
 {% block breadcrumb %}
-<nav aria-label="breadcrumb">
-  <ol class="breadcrumb mb-0">
-    <li class="breadcrumb-item"><a href="{{ url_for('library.list_libraries') }}">Bibliotecas</a></li>
-    <li class="breadcrumb-item"><a href="{{ url_for('library.show_library', lib_id=asset.folder.library_id) }}">{{ asset.folder.library.name }}</a></li>
-    <li class="breadcrumb-item"><a href="{{ url_for('folder.view_folder', folder_id=asset.folder_id) }}">{{ asset.folder.name }}</a></li>
-    <li class="breadcrumb-item active" aria-current="page">{{ asset.filename_orig }}</li>
-  </ol>
-</nav>
+{{ breadcrumb.render([
+  ('Bibliotecas', url_for('library.list_libraries')),
+  (asset.folder.library.name, url_for('library.show_library', lib_id=asset.folder.library_id)),
+  (asset.folder.name, url_for('folder.view_folder', folder_id=asset.folder_id)),
+  (asset.filename_orig, None)
+]) }}
 {% endblock %}
 {% block content %}
 <div class="row">

--- a/arkiv_app/templates/components/breadcrumb.html
+++ b/arkiv_app/templates/components/breadcrumb.html
@@ -1,0 +1,13 @@
+{% macro render(items) %}
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+  {% for label, url in items %}
+    {% if not loop.last and url %}
+      <li class="breadcrumb-item"><a href="{{ url }}">{{ label }}</a></li>
+    {% else %}
+      <li class="breadcrumb-item active" aria-current="page">{{ label }}</li>
+    {% endif %}
+  {% endfor %}
+  </ol>
+</nav>
+{% endmacro %}

--- a/arkiv_app/templates/dashboard/dashboard.html
+++ b/arkiv_app/templates/dashboard/dashboard.html
@@ -1,6 +1,10 @@
 {% extends 'base.html' %}
+{% import 'components/breadcrumb.html' as breadcrumb %}
 {% block breadcrumb %}
-<span class="text-muted">Org: {{ org.name }} &gt; Dashboard</span>
+{{ breadcrumb.render([
+  ('Org: ' ~ org.name, None),
+  ('Dashboard', None)
+]) }}
 {% endblock %}
 {% block content %}
 <h1 class="mb-4">Dashboard</h1>

--- a/arkiv_app/templates/folder/detail.html
+++ b/arkiv_app/templates/folder/detail.html
@@ -1,7 +1,14 @@
 {% extends 'base.html' %}
+{% import 'components/breadcrumb.html' as breadcrumb %}
+{% block breadcrumb %}
+{{ breadcrumb.render([
+  ('Bibliotecas', url_for('library.list_libraries')),
+  (folder.library.name, url_for('library.show_library', lib_id=folder.library_id)),
+  (folder.name, None)
+]) }}
+{% endblock %}
 {% block content %}
 <h1>{{ folder.name }}</h1>
-<p><a href="{{ url_for('library.show_library', lib_id=folder.library_id) }}">Voltar para biblioteca</a></p>
 <a href="{{ url_for('asset.upload_asset', folder_id=folder.id) }}" class="btn btn-accent mb-2"><i class="bi bi-upload"></i> Enviar Arquivo</a>
 <a href="{{ url_for('folder.create_folder') }}?library_id={{ folder.library_id }}&parent_id={{ folder.id }}" class="btn btn-accent mb-3"><i class="bi bi-folder-plus"></i> Nova Subpasta</a>
 <ul class="list-group">

--- a/arkiv_app/templates/library/detail.html
+++ b/arkiv_app/templates/library/detail.html
@@ -1,11 +1,10 @@
 {% extends 'base.html' %}
+{% import 'components/breadcrumb.html' as breadcrumb %}
 {% block breadcrumb %}
-<nav aria-label="breadcrumb">
-  <ol class="breadcrumb mb-0">
-    <li class="breadcrumb-item"><a href="{{ url_for('library.list_libraries') }}">Bibliotecas</a></li>
-    <li class="breadcrumb-item active" aria-current="page">{{ library.name }}</li>
-  </ol>
-</nav>
+{{ breadcrumb.render([
+  ('Bibliotecas', url_for('library.list_libraries')),
+  (library.name, None)
+]) }}
 {% endblock %}
 {% block content %}
 <div class="d-flex justify-content-between align-items-start flex-column flex-sm-row gap-3 mb-4">

--- a/arkiv_app/templates/organization/settings.html
+++ b/arkiv_app/templates/organization/settings.html
@@ -1,6 +1,10 @@
 {% extends 'base.html' %}
+{% import 'components/breadcrumb.html' as breadcrumb %}
 {% block breadcrumb %}
-<span class="text-muted">Org: {{ org.name }} &gt; Configurações</span>
+{{ breadcrumb.render([
+  ('Org: ' ~ org.name, None),
+  ('Configurações', None)
+]) }}
 {% endblock %}
 {% block content %}
 <h1 class="mb-4">Configurações da Organização</h1>


### PR DESCRIPTION
## Summary
- add reusable breadcrumb macro
- apply macro in asset, library, dashboard and organization templates
- add breadcrumb for folder view
- style breadcrumbs with flex and custom separator

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6843568b1d488332af938ea6d188b7b3