### PR TITLE
Refine back button and breadcrumb logic

### DIFF
--- a/arkiv_app/static/css/style.css
+++ b/arkiv_app/static/css/style.css
@@ -78,6 +78,11 @@ button:hover,
   background: var(--accent);
   color: #fff;
 }
+.back-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
 
 /* ---------- Navbar flutuante ---------- */
 .navbar-floating {

--- a/arkiv_app/templates/admin/logs.html
+++ b/arkiv_app/templates/admin/logs.html
@@ -1,7 +1,10 @@
 {% extends 'base.html' %}
+{% import 'components/back_button.html' as back_btn %}
+{% block back %}
+{{ back_btn.back(url_for('admin.index')) }}
+{% endblock %}
 {% block content %}
 <h1>Últimos Logs</h1>
-<p><a href="{{ url_for('admin.index') }}">Voltar</a></p>
 <table class="card" style="width:100%">
   <tr><th>Org</th><th>Usuário</th><th>Ação</th><th>Entidade</th><th>ID</th><th>Data</th></tr>
   {% for l in logs %}

--- a/arkiv_app/templates/admin/orgs.html
+++ b/arkiv_app/templates/admin/orgs.html
@@ -1,7 +1,10 @@
 {% extends 'base.html' %}
+{% import 'components/back_button.html' as back_btn %}
+{% block back %}
+{{ back_btn.back(url_for('admin.index')) }}
+{% endblock %}
 {% block content %}
 <h1>Organizações</h1>
-<p><a href="{{ url_for('admin.index') }}">Voltar</a></p>
 <ul>
   {% for org in orgs %}
   <li class="card">{{ org.name }} ({{ org.slug }})</li>

--- a/arkiv_app/templates/admin/plans.html
+++ b/arkiv_app/templates/admin/plans.html
@@ -1,7 +1,10 @@
 {% extends 'base.html' %}
+{% import 'components/back_button.html' as back_btn %}
+{% block back %}
+{{ back_btn.back(url_for('admin.index')) }}
+{% endblock %}
 {% block content %}
 <h1>Planos</h1>
-<p><a href="{{ url_for('admin.index') }}">Voltar</a></p>
 <ul>
   {% for plan in plans %}
   <li class="card">{{ plan.name }} - {{ plan.storage_quota_gb }}GB</li>

--- a/arkiv_app/templates/admin/users.html
+++ b/arkiv_app/templates/admin/users.html
@@ -1,7 +1,10 @@
 {% extends 'base.html' %}
+{% import 'components/back_button.html' as back_btn %}
+{% block back %}
+{{ back_btn.back(url_for('admin.index')) }}
+{% endblock %}
 {% block content %}
 <h1>Usuários</h1>
-<p><a href="{{ url_for('admin.index') }}">Voltar</a></p>
 <table class="card" style="width:100%">
   <tr><th>Nome</th><th>Email</th><th>Ativo</th><th>Admin</th></tr>
   {% for u in users %}

--- a/arkiv_app/templates/asset/list.html
+++ b/arkiv_app/templates/asset/list.html
@@ -1,7 +1,10 @@
 {% extends 'base.html' %}
+{% import 'components/back_button.html' as back_btn %}
+{% block back %}
+{{ back_btn.back(url_for('folder.view_folder', folder_id=folder.id), 'Voltar para pasta') }}
+{% endblock %}
 {% block content %}
 <h1>Arquivos de {{ folder.name }}</h1>
-<p><a href="{{ url_for('folder.view_folder', folder_id=folder.id) }}">Voltar para pasta</a></p>
 <form method="post" enctype="multipart/form-data" class="card guarded-form">
   {{ form.hidden_tag() }}
   <div class="field">{{ form.file() }}</div>

--- a/arkiv_app/templates/base.html
+++ b/arkiv_app/templates/base.html
@@ -19,7 +19,7 @@
   <main id="content">
     <div class="floating-container container-fluid">
       {% if not login_page %}
-      <a href="{{ request.referrer or url_for('main.index') }}" class="btn btn-outline-accent back-btn mb-3" onclick="if (history.length > 1) { history.back(); return false; }">Voltar</a>
+      {% block back %}{% endblock %}
       {% block breadcrumb %}{% endblock %}
       {% endif %}
       {% with messages = get_flashed_messages() %}

--- a/arkiv_app/templates/components/back_button.html
+++ b/arkiv_app/templates/components/back_button.html
@@ -1,0 +1,3 @@
+{% macro back(url, label='Voltar') %}
+<a href="{{ url }}" class="btn btn-outline-accent back-btn mb-3"><i class="bi bi-chevron-left"></i> {{ label }}</a>
+{% endmacro %}


### PR DESCRIPTION
## Summary
- add `back_button` component
- remove default back button from base template
- update admin and asset templates to use the new component
- tweak CSS with `.back-btn` helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68435797bd00833292e3e62bcae06bdf