### PR TITLE
Implement card redesign

### DIFF
--- a/arkiv_app/static/css/cards.css
+++ b/arkiv_app/static/css/cards.css
@@ -1,0 +1,105 @@
+/* Componentes de cards para bibliotecas, pastas e assets */
+
+.library-card {
+  position: relative;
+  display: flex;
+  gap: 0.75rem;
+  padding: 1rem;
+  background: var(--card-bg);
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.08);
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+.library-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+}
+.library-thumb {
+  width: 48px;
+  height: 48px;
+  border-radius: 6px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--accent);
+  color: #fff;
+  font-weight: var(--w-semibold);
+  flex-shrink: 0;
+}
+.library-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.library-menu {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.25rem;
+}
+.library-metrics {
+  font-size: 0.875rem;
+}
+
+.folder-tile {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: var(--card-bg);
+  border-radius: 6px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.05);
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+.folder-tile:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+}
+.folder-badge {
+  background: var(--accent);
+  color: #fff;
+  font-size: 0.75rem;
+}
+
+.asset-gallery {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(200px,1fr));
+}
+.asset-item {
+  position: relative;
+  overflow: hidden;
+  border-radius: 6px;
+}
+.asset-item-selectable input[type="checkbox"] {
+  position: absolute;
+  top: 0.25rem;
+  left: 0.25rem;
+  z-index: 2;
+}
+.asset-item-selectable.selected {
+  outline: 3px solid var(--accent);
+}
+.asset-item img {
+  width: 100%;
+  height: 120px;
+  object-fit: cover;
+  display: block;
+}
+.asset-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+.asset-item:hover .asset-overlay {
+  opacity: 1;
+}
+.text-accent{color:var(--accent);}
+

--- a/arkiv_app/static/js/gallery.js
+++ b/arkiv_app/static/js/gallery.js
@@ -1,0 +1,19 @@
+// Seleção simples em galerias de assets
+document.addEventListener('click', function(e){
+  const item = e.target.closest('.asset-item-selectable');
+  if(item && e.target.matches('input[type="checkbox"]')){
+    item.classList.toggle('selected', e.target.checked);
+  }
+});
+
+// Placeholder para infinite scroll
+const sentinel = document.querySelector('[data-gallery-sentinel]');
+if(sentinel){
+  const observer = new IntersectionObserver((entries)=>{
+    if(entries[0].isIntersecting){
+      const event = new CustomEvent('gallery:loadMore');
+      document.dispatchEvent(event);
+    }
+  });
+  observer.observe(sentinel);
+}

--- a/arkiv_app/templates/asset/gallery.html
+++ b/arkiv_app/templates/asset/gallery.html
@@ -1,0 +1,18 @@
+<div class="asset-gallery">
+  {% for asset in assets %}
+  <div class="asset-item asset-item-selectable">
+    <input type="checkbox" class="form-check-input">
+    <img src="{{ url_for('asset.asset_file', asset_id=asset.id) }}" alt="{{ asset.filename_orig }}" loading="lazy">
+    <div class="asset-overlay">
+      <a href="{{ url_for('asset.view_asset', asset_id=asset.id) }}" class="btn btn-sm btn-light"><i class="bi bi-pencil"></i></a>
+      <a href="{{ url_for('asset.download_asset', asset_id=asset.id) }}" class="btn btn-sm btn-light"><i class="bi bi-download"></i></a>
+      <form action="{{ url_for('asset.delete_asset', asset_id=asset.id) }}" method="post" onsubmit="return confirm('Excluir arquivo?');" class="d-inline">
+        <button class="btn btn-sm btn-danger" type="submit"><i class="bi bi-trash"></i></button>
+      </form>
+    </div>
+  </div>
+  {% else %}
+  <p class="text-muted">Nenhum arquivo</p>
+  {% endfor %}
+</div>
+<div data-gallery-sentinel></div>

--- a/arkiv_app/templates/asset/list.html
+++ b/arkiv_app/templates/asset/list.html
@@ -13,11 +13,6 @@
     <a href="{{ url_for('folder.view_folder', folder_id=folder.id) }}" class="btn btn-secondary btn-cancel">Cancelar</a>
   </div>
 </form>
-<ul>
-  {% for asset in assets %}
-  <li>{{ asset.filename_orig }} ({{ asset.size }} bytes)</li>
-  {% else %}
-  <li>Nenhum arquivo</li>
-  {% endfor %}
-</ul>
+{% set assets = assets %}
+{% include 'asset/gallery.html' %}
 {% endblock %}

--- a/arkiv_app/templates/base.html
+++ b/arkiv_app/templates/base.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/cards.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/forms.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/reset-overrides.css') }}">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
@@ -38,6 +39,7 @@
   <script src="{{ url_for('static', filename='js/theme.js') }}"></script>
   <script src="{{ url_for('static', filename='js/main.js') }}"></script>
   <script src="{{ url_for('static', filename='js/user-modal.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/gallery.js') }}"></script>
   {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/arkiv_app/templates/folder/_tile.html
+++ b/arkiv_app/templates/folder/_tile.html
@@ -1,0 +1,5 @@
+<div class="folder-tile">
+  <i class="bi bi-folder text-accent"></i>
+  <a class="flex-grow-1 text-decoration-none" href="{{ url_for('folder.view_folder', folder_id=folder.id) }}">{{ folder.name }}</a>
+  <span class="badge folder-badge">{{ item_count }}</span>
+</div>

--- a/arkiv_app/templates/folder/detail.html
+++ b/arkiv_app/templates/folder/detail.html
@@ -11,11 +11,13 @@
 <h1>{{ folder.name }}</h1>
 <a href="{{ url_for('asset.upload_asset', folder_id=folder.id) }}" class="btn btn-accent mb-2"><i class="bi bi-upload"></i> Enviar Arquivo</a>
 <a href="{{ url_for('folder.create_folder') }}?library_id={{ folder.library_id }}&parent_id={{ folder.id }}" class="btn btn-accent mb-3"><i class="bi bi-folder-plus"></i> Nova Subpasta</a>
-<ul class="list-group">
+<div class="d-grid gap-2">
   {% for sub in subfolders %}
-  <li class="list-group-item"><a href="{{ url_for('folder.view_folder', folder_id=sub.id) }}">{{ sub.name }}</a></li>
+  {% set folder = sub %}
+  {% set item_count = sub.assets|length + sub.children|length %}
+  {% include 'folder/_tile.html' %}
   {% else %}
-  <li class="list-group-item">Nenhuma subpasta</li>
+  <p class="text-muted">Nenhuma subpasta</p>
   {% endfor %}
-</ul>
+</div>
 {% endblock %}

--- a/arkiv_app/templates/library/_card.html
+++ b/arkiv_app/templates/library/_card.html
@@ -1,0 +1,25 @@
+<article class="library-card">
+  <div class="library-thumb">
+    {% if library.thumbnail_url %}
+    <img src="{{ library.thumbnail_url }}" alt="thumb" loading="lazy">
+    {% else %}
+    <span>{{ library.name[0]|upper }}</span>
+    {% endif %}
+  </div>
+  <div class="flex-grow-1">
+    <h5 class="library-title mb-0"><a href="{{ url_for('library.show_library', lib_id=library.id) }}">{{ library.name }}</a></h5>
+    {% if library.description %}<p class="text-muted small mb-1">{{ library.description|truncate(100) }}</p>{% endif %}
+    <div class="library-metrics text-muted">{{ asset_count }} imagens · {{ library.created_at.strftime('%d/%m/%Y') }}</div>
+  </div>
+  <div class="library-menu dropdown">
+    <button class="btn btn-sm btn-link text-muted" data-bs-toggle="dropdown" aria-label="Ações"><i class="bi bi-three-dots-vertical"></i></button>
+    <ul class="dropdown-menu dropdown-menu-end">
+      <li><a class="dropdown-item" href="{{ url_for('library.edit_library', lib_id=library.id) }}">Editar</a></li>
+      <li>
+        <form action="{{ url_for('library.delete_library', lib_id=library.id) }}" method="post" onsubmit="return confirm('Remover biblioteca?');">
+          <button type="submit" class="dropdown-item text-danger">Deletar</button>
+        </form>
+      </li>
+    </ul>
+  </div>
+</article>

--- a/arkiv_app/templates/library/detail.html
+++ b/arkiv_app/templates/library/detail.html
@@ -22,27 +22,22 @@
       <h6 class="mb-0">Pastas</h6>
       <a href="{{ url_for('folder.create_folder') }}?library_id={{ library.id }}" class="btn btn-sm btn-accent" aria-label="Nova Pasta"><i class="bi bi-folder-plus"></i></a>
     </div>
-    <ul class="list-group folder-list">
+    <div class="d-grid gap-2">
       {% for folder in folders %}
-      <li class="list-group-item"><a href="{{ url_for('folder.view_folder', folder_id=folder.id) }}">{{ folder.name }}</a></li>
+      {% set item_count = folder.assets|length + folder.children|length %}
+      {% include 'folder/_tile.html' %}
       {% else %}
-      <li class="list-group-item text-muted">Nenhuma pasta</li>
+      <p class="text-muted">Nenhuma pasta</p>
       {% endfor %}
-    </ul>
+    </div>
   </div>
   <div class="col-md-9">
     <div class="d-flex justify-content-between align-items-center mb-3">
       <h6 class="mb-0">Arquivos recentes</h6>
     </div>
     {% if assets %}
-    <div class="asset-grid">
-      {% for a in assets %}
-      <div class="asset-card">
-        <img src="{{ url_for('static', filename='img/avatar.svg') }}" alt="thumb">
-        <div class="asset-info">{{ a.filename_orig }}</div>
-      </div>
-      {% endfor %}
-    </div>
+    {% set assets = assets %}
+    {% include 'asset/gallery.html' %}
     {% else %}
     <div class="text-center p-5 border rounded bg-light">
       <p class="lead mb-3">Nada aqui ainda. Faça seu primeiro upload!</p>

--- a/arkiv_app/templates/library/list.html
+++ b/arkiv_app/templates/library/list.html
@@ -15,19 +15,9 @@
   {% for item in libraries %}
   {% set lib = item.instance %}
   <div class="col">
-    <article class="card library-card h-100">
-      <div class="library-card__title">
-        <h5 class="mb-1"><a href="{{ url_for('library.show_library', lib_id=lib.id) }}">{{ lib.name }}</a></h5>
-        <small>{{ item.asset_count }} imagens</small>
-      </div>
-      {% if lib.description %}<p class="text-muted small">{{ lib.description|truncate(100) }}</p>{% endif %}
-      <div class="library-actions mt-auto">
-        <a href="{{ url_for('library.edit_library', lib_id=lib.id) }}" class="btn-outline-accent">Editar</a>
-        <form action="{{ url_for('library.delete_library', lib_id=lib.id) }}" method="post" onsubmit="return confirm('Remover biblioteca?');">
-          <button type="submit" class="btn-delete">Deletar</button>
-        </form>
-      </div>
-    </article>
+    {% set library = lib %}
+    {% set asset_count = item.asset_count %}
+    {% include 'library/_card.html' %}
   </div>
   {% endfor %}
 </div>


### PR DESCRIPTION
## Summary
- add new card, tile and gallery partials
- update library, folder and asset templates to use new components
- create shared cards.css with hover and grid styles
- include gallery.js for selectable assets and infinite scroll placeholder
- register new assets in base template

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68435915b0a883328570027c21b9d9b7