### PR TITLE
Improve form layout and upload UI

### DIFF
--- a/arkiv_app/static/css/forms.css
+++ b/arkiv_app/static/css/forms.css
@@ -19,3 +19,38 @@ textarea:focus {
   border-color: var(--accent);
   box-shadow: 0 0 0 3px rgba(40, 160, 176, 0.35);
 }
+.form-error {
+  color: var(--danger);
+  font-size: 0.875rem;
+  margin-top: 0.25rem;
+}
+.form-error::before {
+  content: "\26A0\fe0f ";
+}
+input[type="checkbox"],
+input[type="radio"] {
+  width: 24px;
+  height: 24px;
+}
+input[type="checkbox"]:focus,
+input[type="radio"]:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(40, 160, 176, 0.35);
+}
+.form-upload {
+  border: 2px dashed #ccc;
+  padding: 1.5rem;
+  text-align: center;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.form-upload.dragover {
+  border-color: var(--accent);
+  background: rgba(40, 160, 176, 0.05);
+}
+.form-upload img {
+  max-width: 100px;
+  max-height: 80px;
+  object-fit: cover;
+  margin: 0.5rem;
+}

--- a/arkiv_app/static/js/upload.js
+++ b/arkiv_app/static/js/upload.js
@@ -1,0 +1,63 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.querySelector('#upload-form');
+  if (!form) return;
+  const input = form.querySelector('input[type="file"]');
+  const area = document.querySelector('#upload-area');
+  const preview = document.querySelector('#preview');
+  const progressBar = form.querySelector('.progress-bar');
+  const progressWrap = form.querySelector('.progress');
+
+  const showPreviews = (files) => {
+    if (!preview) return;
+    preview.innerHTML = '';
+    Array.from(files).forEach(file => {
+      const reader = new FileReader();
+      reader.onload = (ev) => {
+        const img = document.createElement('img');
+        img.src = ev.target.result;
+        preview.appendChild(img);
+      };
+      reader.readAsDataURL(file);
+    });
+  };
+
+  area.addEventListener('click', () => input.click());
+  area.addEventListener('dragover', (e) => {
+    e.preventDefault();
+    area.classList.add('dragover');
+  });
+  area.addEventListener('dragleave', () => {
+    area.classList.remove('dragover');
+  });
+  area.addEventListener('drop', (e) => {
+    e.preventDefault();
+    area.classList.remove('dragover');
+    input.files = e.dataTransfer.files;
+    showPreviews(input.files);
+  });
+  input.addEventListener('change', () => showPreviews(input.files));
+
+  form.addEventListener('submit', (e) => {
+    if (!progressBar) return;
+    e.preventDefault();
+    progressWrap.classList.remove('d-none');
+    const xhr = new XMLHttpRequest();
+    xhr.open('POST', form.action);
+    xhr.upload.addEventListener('progress', (ev) => {
+      if (ev.lengthComputable) {
+        const pct = Math.round((ev.loaded / ev.total) * 100);
+        progressBar.style.width = pct + '%';
+        progressBar.textContent = pct + '%';
+      }
+    });
+    xhr.onload = () => {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        location.reload();
+      } else {
+        alert('Erro ao enviar arquivo');
+      }
+    };
+    const formData = new FormData(form);
+    xhr.send(formData);
+  });
+});

--- a/arkiv_app/templates/asset/list.html
+++ b/arkiv_app/templates/asset/list.html
@@ -5,14 +5,33 @@
 {% endblock %}
 {% block content %}
 <h1>Arquivos de {{ folder.name }}</h1>
-<form method="post" enctype="multipart/form-data" class="card guarded-form">
+<form method="post" enctype="multipart/form-data" class="card p-4 guarded-form" id="upload-form">
   {{ form.hidden_tag() }}
-  <div class="field">{{ form.file() }}</div>
+  <div class="row mb-3">
+    {{ form.file.label(class_='col-12 col-md-3 form-label') }}
+    <div class="col-12 col-md-9">
+      <div id="upload-area" class="form-upload">
+        <p class="mb-0">Arraste arquivos ou clique para selecionar</p>
+        {{ form.file(class_='form-control', multiple=True, style='display:none') }}
+        <div id="preview" class="d-flex flex-wrap mt-2"></div>
+      </div>
+      {% if form.file.errors %}
+      <div class="form-error">{{ form.file.errors[0] }}</div>
+      {% endif %}
+    </div>
+  </div>
   <div class="d-flex gap-2">
-    {{ form.submit(class_='btn') }}
-    <a href="{{ url_for('folder.view_folder', folder_id=folder.id) }}" class="btn btn-secondary btn-cancel">Cancelar</a>
+    {{ form.submit(class_='btn btn-accent', id='upload-submit') }}
+    <a href="{{ url_for('folder.view_folder', folder_id=folder.id) }}" class="btn btn-outline-accent btn-cancel">Cancelar</a>
+  </div>
+  <div class="progress mt-3 d-none">
+    <div class="progress-bar" role="progressbar"></div>
   </div>
 </form>
 {% set assets = assets %}
 {% include 'asset/gallery.html' %}
+{% endblock %}
+{% block scripts %}
+{{ super() }}
+<script src="{{ url_for('static', filename='js/upload.js') }}"></script>
 {% endblock %}

--- a/arkiv_app/templates/folder/form.html
+++ b/arkiv_app/templates/folder/form.html
@@ -1,14 +1,38 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Pasta</h1>
-<form method="post" class="card guarded-form">
+<form method="post" class="card p-4 guarded-form">
   {{ form.hidden_tag() }}
-  <div class="field">{{ form.library_id.label }} {{ form.library_id() }}</div>
-  <div class="field">{{ form.parent_id.label }} {{ form.parent_id() }}</div>
-  <div class="field">{{ form.name.label }} {{ form.name(size=32, required=True) }}</div>
+  <div class="row mb-3">
+    {{ form.library_id.label(class_='col-12 col-md-3 form-label') }}
+    <div class="col-12 col-md-9">
+      {{ form.library_id(class_='form-select') }}
+      {% if form.library_id.errors %}
+      <div class="form-error">{{ form.library_id.errors[0] }}</div>
+      {% endif %}
+    </div>
+  </div>
+  <div class="row mb-3">
+    {{ form.parent_id.label(class_='col-12 col-md-3 form-label') }}
+    <div class="col-12 col-md-9">
+      {{ form.parent_id(class_='form-select') }}
+      {% if form.parent_id.errors %}
+      <div class="form-error">{{ form.parent_id.errors[0] }}</div>
+      {% endif %}
+    </div>
+  </div>
+  <div class="row mb-3">
+    {{ form.name.label(class_='col-12 col-md-3 form-label') }}
+    <div class="col-12 col-md-9">
+      {{ form.name(class_='form-control', required=True) }}
+      {% if form.name.errors %}
+      <div class="form-error">{{ form.name.errors[0] }}</div>
+      {% endif %}
+    </div>
+  </div>
   <div class="d-flex gap-2">
     {{ form.submit(class_='btn btn-accent') }}
-    <a href="{{ url_for('library.list_libraries') }}" class="btn btn-outline-secondary btn-cancel">Cancelar</a>
+    <a href="{{ url_for('library.list_libraries') }}" class="btn btn-outline-accent btn-cancel">Cancelar</a>
   </div>
 </form>
 {% from 'components/form_dirty_guard.html' import guard %}

--- a/arkiv_app/templates/library/form.html
+++ b/arkiv_app/templates/library/form.html
@@ -1,13 +1,29 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Biblioteca</h1>
-<form method="post" class="card guarded-form">
+<form method="post" class="card p-4 guarded-form">
   {{ form.hidden_tag() }}
-  <div class="field">{{ form.name.label }} {{ form.name(size=32, required=True) }}</div>
-  <div class="field">{{ form.description.label }} {{ form.description(cols=40, rows=4) }}</div>
+  <div class="row mb-3">
+    {{ form.name.label(class_='col-12 col-md-3 form-label') }}
+    <div class="col-12 col-md-9">
+      {{ form.name(class_='form-control', required=True) }}
+      {% if form.name.errors %}
+      <div class="form-error">{{ form.name.errors[0] }}</div>
+      {% endif %}
+    </div>
+  </div>
+  <div class="row mb-3">
+    {{ form.description.label(class_='col-12 col-md-3 form-label') }}
+    <div class="col-12 col-md-9">
+      {{ form.description(class_='form-control', rows=4) }}
+      {% if form.description.errors %}
+      <div class="form-error">{{ form.description.errors[0] }}</div>
+      {% endif %}
+    </div>
+  </div>
   <div class="d-flex gap-2">
     {{ form.submit(class_='btn btn-accent') }}
-    <a href="{{ url_for('library.list_libraries') }}" class="btn btn-outline-secondary btn-cancel">Cancelar</a>
+    <a href="{{ url_for('library.list_libraries') }}" class="btn btn-outline-accent btn-cancel">Cancelar</a>
   </div>
 </form>
 {% from 'components/form_dirty_guard.html' import guard %}


### PR DESCRIPTION
## Summary
- polish forms.css and add new styles
- redesign library, folder and asset forms using Bootstrap grid
- add drag-and-drop upload area with preview and progress

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68435a6ed62883329a892e456d06ddef