### PR TITLE
Add toast notifications and empty state component

### DIFF
--- a/arkiv_app/asset/routes.py
+++ b/arkiv_app/asset/routes.py
@@ -51,7 +51,7 @@ def upload_asset(folder_id):
         quota = org.plan.storage_quota_gb * 1024 * 1024 * 1024
         if used + size > quota:
             os.remove(filepath)
-            flash("Limite de armazenamento excedido")
+            flash("Limite de armazenamento excedido!", "error")
             return redirect(url_for("asset.upload_asset", folder_id=folder.id))
         asset = Asset(
             library_id=folder.library_id,
@@ -70,7 +70,7 @@ def upload_asset(folder_id):
         )
         generate_thumbnail.delay(asset.id, upload_path, thumb_path)
         perform_ocr.delay(asset.id)
-        flash("Arquivo enviado")
+        flash("Upload concluído!", "success")
         return redirect(url_for("asset.upload_asset", folder_id=folder.id))
     assets = Asset.query.filter_by(folder_id=folder_id).all()
     return render_template(
@@ -113,5 +113,5 @@ def delete_asset(asset_id):
     asset.deleted_at = datetime.utcnow()
     db.session.commit()
     record_audit("delete", "asset", asset.id, user_id=current_user.id, org_id=asset.folder.library.org_id)
-    flash("Asset removido")
+    flash("Asset removido!", "success")
     return redirect(url_for("folder.view_folder", folder_id=asset.folder_id))

--- a/arkiv_app/folder/routes.py
+++ b/arkiv_app/folder/routes.py
@@ -29,7 +29,7 @@ def create_folder():
     org_id = current_org_id()
     libs = Library.query.filter_by(org_id=org_id).all()
     if not libs:
-        flash("Crie uma biblioteca antes de adicionar pastas")
+        flash("Crie uma biblioteca antes de adicionar pastas", "warning")
         return redirect(url_for("library.create_library"))
     if request.args.get("library_id"):
         form.library_id.data = int(request.args["library_id"])
@@ -52,7 +52,7 @@ def create_folder():
             user_id=current_user.id,
             org_id=org_id,
         )
-        flash("Pasta criada")
+        flash("Pasta criada!", "success")
         return redirect(url_for("library.list_libraries"))
     return render_template("folder/form.html", form=form, title="Nova Pasta")
 
@@ -66,7 +66,7 @@ def edit_folder(folder_id):
     org_id = current_org_id()
     libs = Library.query.filter_by(org_id=org_id).all()
     if not libs:
-        flash("Crie uma biblioteca antes de adicionar pastas")
+        flash("Crie uma biblioteca antes de adicionar pastas", "warning")
         return redirect(url_for("library.create_library"))
     _populate_form_choices(form, libs)
     if form.validate_on_submit():
@@ -81,7 +81,7 @@ def edit_folder(folder_id):
             user_id=current_user.id,
             org_id=org_id,
         )
-        flash("Pasta atualizada")
+        flash("Pasta atualizada!", "success")
         return redirect(url_for("library.list_libraries"))
     return render_template("folder/form.html", form=form, title="Editar Pasta")
 
@@ -100,7 +100,7 @@ def delete_folder(folder_id):
         user_id=current_user.id,
         org_id=current_org_id(),
     )
-    flash("Pasta removida")
+    flash("Pasta removida!", "success")
     return redirect(url_for("library.list_libraries"))
 
 

--- a/arkiv_app/library/routes.py
+++ b/arkiv_app/library/routes.py
@@ -96,7 +96,7 @@ def create_library():
         record_audit(
             "create", "library", lib.id, user_id=current_user.id, org_id=org_id
         )
-        flash("Biblioteca criada")
+        flash("Biblioteca criada!", "success")
         return redirect(url_for("library.list_libraries"))
     return render_template("library/form.html", form=form, title="Nova Biblioteca")
 
@@ -118,7 +118,7 @@ def edit_library(lib_id):
             user_id=current_user.id,
             org_id=current_org_id(),
         )
-        flash("Biblioteca atualizada")
+        flash("Biblioteca atualizada!", "success")
         return redirect(url_for("library.list_libraries"))
     return render_template("library/form.html", form=form, title="Editar Biblioteca")
 
@@ -137,5 +137,5 @@ def delete_library(lib_id):
         user_id=current_user.id,
         org_id=current_org_id(),
     )
-    flash("Biblioteca removida")
+    flash("Biblioteca removida!", "success")
     return redirect(url_for("library.list_libraries"))

--- a/arkiv_app/organization/routes.py
+++ b/arkiv_app/organization/routes.py
@@ -21,7 +21,7 @@ def settings():
     if form.validate_on_submit():
         org.name = form.name.data
         db.session.commit()
-        flash('Configurações salvas')
+        flash('Configurações salvas!', 'success')
         return redirect(url_for('organization.settings'))
 
     used_storage = (
@@ -63,9 +63,9 @@ def members():
             m = Membership(user_id=user.id, org_id=org.id, role=invite_form.role.data)
             db.session.add(m)
             db.session.commit()
-            flash('Usuário convidado')
+            flash('Usuário convidado', 'success')
         else:
-            flash('Usuário já é membro')
+            flash('Usuário já é membro', 'warning')
         return redirect(url_for('organization.members'))
 
     q = request.args.get('q', '')
@@ -108,11 +108,11 @@ def update_member_role(user_id):
     new_role = request.form.get('role')
     mem = Membership.query.filter_by(user_id=user_id, org_id=org.id).first_or_404()
     if mem.user_id == current_user.id and mem.role == 'OWNER' and new_role != 'OWNER':
-        flash('Você não pode rebaixar seu próprio papel de OWNER')
+        flash('Você não pode rebaixar seu próprio papel de OWNER', 'warning')
         return redirect(url_for('organization.members'))
     mem.role = new_role
     db.session.commit()
-    flash('Permissão alterada!')
+    flash('Permissão alterada!', 'success')
     return redirect(url_for('organization.members'))
 
 
@@ -126,9 +126,9 @@ def remove_member(user_id):
     if mem.role == 'OWNER':
         owner_count = Membership.query.filter_by(org_id=org.id, role='OWNER').count()
         if owner_count <= 1:
-            flash('Não é possível remover o último OWNER')
+            flash('Não é possível remover o último OWNER', 'error')
             return redirect(url_for('organization.members'))
     db.session.delete(mem)
     db.session.commit()
-    flash('Usuário removido')
+    flash('Usuário removido', 'success')
     return redirect(url_for('organization.members'))

--- a/arkiv_app/static/css/style.css
+++ b/arkiv_app/static/css/style.css
@@ -364,3 +364,56 @@ nav[aria-label="breadcrumb"] .breadcrumb-item.active {
     gap: 0.5rem;
   }
 }
+
+/* ---------- Toasts ---------- */
+.toast-container {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 2000;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-radius: 4px;
+  color: #fff;
+  min-width: 200px;
+  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+}
+.toast-success {
+  background: #28a745;
+}
+.toast-warning {
+  background: #ffc107;
+  color: #212529;
+}
+.toast-error {
+  background: #dc3545;
+}
+.toast button {
+  background: transparent;
+  border: none;
+  color: inherit;
+  margin-left: auto;
+  font-size: 1rem;
+  line-height: 1;
+}
+
+/* ---------- Empty States ---------- */
+.empty-state {
+  padding: 2rem;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+}
+.empty-state img {
+  max-width: 240px;
+}

--- a/arkiv_app/static/img/empty.svg
+++ b/arkiv_app/static/img/empty.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 150" width="200" height="150">
+  <rect width="200" height="150" fill="#f8f9fa"/>
+  <path d="M60 100h80v10H60zM60 80h80v10H60zM60 60h80v10H60z" fill="#dee2e6"/>
+  <circle cx="100" cy="30" r="20" fill="#ced4da"/>
+</svg>

--- a/arkiv_app/static/js/main.js
+++ b/arkiv_app/static/js/main.js
@@ -1,7 +1,12 @@
 document.addEventListener('DOMContentLoaded', () => {
 
-  document.querySelectorAll('.flash-item').forEach((el) => {
-    setTimeout(() => el.remove(), 5000);
+  document.querySelectorAll('.toast').forEach((el) => {
+    const timer = setTimeout(() => el.remove(), 4000);
+    const btn = el.querySelector('button');
+    if (btn) btn.addEventListener('click', () => {
+      clearTimeout(timer);
+      el.remove();
+    });
   });
 
   const forms = document.querySelectorAll('.guarded-form');

--- a/arkiv_app/tag/routes.py
+++ b/arkiv_app/tag/routes.py
@@ -59,7 +59,7 @@ def create_tag():
         db.session.add(tag)
         db.session.commit()
         record_audit('create', 'tag', tag.id, user_id=current_user.id, org_id=org_id)
-        flash('Tag criada')
+        flash('Tag criada', 'success')
         return redirect(url_for('tag.list_tags'))
     return render_template('tag/form.html', form=form, title='Nova Tag')
 
@@ -74,7 +74,7 @@ def edit_tag(tag_id):
         tag.color_hex = form.color_hex.data
         db.session.commit()
         record_audit('update', 'tag', tag.id, user_id=current_user.id, org_id=current_org_id())
-        flash('Tag atualizada')
+        flash('Tag atualizada', 'success')
         return redirect(url_for('tag.list_tags'))
     return render_template('tag/form.html', form=form, title='Editar Tag')
 
@@ -86,7 +86,7 @@ def delete_tag(tag_id):
     db.session.delete(tag)
     db.session.commit()
     record_audit('delete', 'tag', tag.id, user_id=current_user.id, org_id=current_org_id())
-    flash('Tag removida')
+    flash('Tag removida', 'success')
     return redirect(url_for('tag.list_tags'))
 
 
@@ -97,5 +97,5 @@ def set_asset_tags(asset_id):
     tag_ids = request.form.getlist('tag_ids')
     asset.tags = Tag.query.filter(Tag.id.in_(tag_ids)).all()
     db.session.commit()
-    flash('Tags atualizadas')
+    flash('Tags atualizadas', 'success')
     return redirect(request.referrer or url_for('asset.upload_asset', folder_id=asset.folder_id))

--- a/arkiv_app/templates/asset/gallery.html
+++ b/arkiv_app/templates/asset/gallery.html
@@ -12,7 +12,12 @@
     </div>
   </div>
   {% else %}
-  <p class="text-muted">Nenhum arquivo</p>
+  {% include 'components/empty.html' with
+      img='empty.svg',
+      title='Nenhum arquivo',
+      description='Use o botão acima para enviar arquivos.',
+      cta_url=url_for('asset.upload_asset', folder_id=folder.id) if folder else None,
+      cta_label='Upload' %}
   {% endfor %}
 </div>
 <div data-gallery-sentinel></div>

--- a/arkiv_app/templates/base.html
+++ b/arkiv_app/templates/base.html
@@ -23,15 +23,23 @@
       {% block back %}{% endblock %}
       {% block breadcrumb %}{% endblock %}
       {% endif %}
-      {% with messages = get_flashed_messages() %}
-        {% if messages %}
-        <ul class="flash">
-          {% for m in messages %}
-          <li class="flash-item">{{ m }} <button class="flash-close" aria-label="Fechar" onclick="this.parentElement.remove()">&times;</button></li>
+      <div class="toast-container">
+        {% with messages = get_flashed_messages(with_categories=True) %}
+          {% for category, m in messages %}
+          <div class="toast toast-{{ category }}" role="status">
+            {% if category == 'success' %}
+            <i class="bi bi-check-circle-fill"></i>
+            {% elif category == 'warning' %}
+            <i class="bi bi-exclamation-triangle-fill"></i>
+            {% else %}
+            <i class="bi bi-x-circle-fill"></i>
+            {% endif %}
+            <span>{{ m }}</span>
+            <button aria-label="Fechar">&times;</button>
+          </div>
           {% endfor %}
-        </ul>
-        {% endif %}
-      {% endwith %}
+        {% endwith %}
+      </div>
       {% block content %}{% endblock %}
     </div>
   </main>

--- a/arkiv_app/templates/components/empty.html
+++ b/arkiv_app/templates/components/empty.html
@@ -1,0 +1,12 @@
+<div class="empty-state">
+  {% if img %}
+  <img src="{{ url_for('static', filename='img/' + img) }}" alt="" class="mb-3">
+  {% endif %}
+  <h2 class="h4">{{ title }}</h2>
+  {% if description %}
+  <p class="text-muted">{{ description }}</p>
+  {% endif %}
+  {% if cta_url and cta_label %}
+  <a href="{{ cta_url }}" class="btn btn-accent btn-lg">{{ cta_label }}</a>
+  {% endif %}
+</div>

--- a/arkiv_app/templates/folder/detail.html
+++ b/arkiv_app/templates/folder/detail.html
@@ -17,7 +17,12 @@
   {% set item_count = sub.assets|length + sub.children|length %}
   {% include 'folder/_tile.html' %}
   {% else %}
-  <p class="text-muted">Nenhuma subpasta</p>
+  {% include 'components/empty.html' with
+      img='empty.svg',
+      title='Esta pasta está vazia',
+      description="Clique em 'Enviar Arquivo' para adicionar arquivos.",
+      cta_url=url_for('asset.upload_asset', folder_id=folder.id),
+      cta_label='Enviar Arquivo' %}
   {% endfor %}
 </div>
 {% endblock %}

--- a/arkiv_app/templates/library/detail.html
+++ b/arkiv_app/templates/library/detail.html
@@ -27,7 +27,12 @@
       {% set item_count = folder.assets|length + folder.children|length %}
       {% include 'folder/_tile.html' %}
       {% else %}
-      <p class="text-muted">Nenhuma pasta</p>
+      {% include 'components/empty.html' with
+          img='empty.svg',
+          title='Nenhuma pasta',
+          description='Crie uma pasta para organizar seus arquivos.',
+          cta_url=url_for('folder.create_folder') ~ '?library_id=' ~ library.id,
+          cta_label='Nova Pasta' %}
       {% endfor %}
     </div>
   </div>
@@ -39,10 +44,12 @@
     {% set assets = assets %}
     {% include 'asset/gallery.html' %}
     {% else %}
-    <div class="text-center p-5 border rounded bg-light">
-      <p class="lead mb-3">Nada aqui ainda. Faça seu primeiro upload!</p>
-      <a href="{{ url_for('folder.create_folder') }}?library_id={{ library.id }}" class="btn btn-accent"><i class="bi bi-folder-plus"></i> Nova Pasta</a>
-    </div>
+    {% include 'components/empty.html' with
+        img='empty.svg',
+        title='Nada aqui ainda',
+        description='Envie arquivos ou crie uma pasta para começar.',
+        cta_url=url_for('folder.create_folder') ~ '?library_id=' ~ library.id,
+        cta_label='Nova Pasta' %}
     {% endif %}
   </div>
 </div>

--- a/arkiv_app/templates/library/list.html
+++ b/arkiv_app/templates/library/list.html
@@ -22,9 +22,11 @@
   {% endfor %}
 </div>
 {% else %}
-<div class="text-center py-5">
-  <p class="lead">Você ainda não criou nenhuma biblioteca. Comece agora!</p>
-  <a href="{{ url_for('library.create_library') }}" class="btn btn-accent btn-lg"><i class="bi bi-plus-circle"></i> Criar primeira biblioteca</a>
-</div>
+{% include 'components/empty.html' with
+    img='empty.svg',
+    title='Nenhuma biblioteca encontrada',
+    description='Crie sua primeira biblioteca para começar a organizar seus arquivos.',
+    cta_url=url_for('library.create_library'),
+    cta_label='Criar Minha Primeira Biblioteca' %}
 {% endif %}
 {% endblock %}

--- a/arkiv_app/trash/routes.py
+++ b/arkiv_app/trash/routes.py
@@ -38,12 +38,12 @@ def restore_asset(asset_id):
     asset = Asset.query.get_or_404(asset_id)
     org_id = current_org_id()
     if asset.folder.library.org_id != org_id or not asset.deleted_at:
-        flash('Ação inválida')
+        flash('Ação inválida', 'error')
         return redirect(url_for('trash.list_trash'))
     asset.deleted_at = None
     db.session.commit()
     record_audit('restore', 'asset', asset.id, user_id=current_user.id, org_id=org_id)
-    flash('Arquivo restaurado!')
+    flash('Arquivo restaurado!', 'success')
     return redirect(url_for('trash.list_trash'))
 
 
@@ -53,7 +53,7 @@ def purge_asset(asset_id):
     asset = Asset.query.get_or_404(asset_id)
     org_id = current_org_id()
     if asset.folder.library.org_id != org_id or not asset.deleted_at:
-        flash('Ação inválida')
+        flash('Ação inválida', 'error')
         return redirect(url_for('trash.list_trash'))
     upload_path = current_app.config['UPLOAD_FOLDER']
     thumb_path = current_app.config['THUMB_FOLDER']
@@ -68,5 +68,5 @@ def purge_asset(asset_id):
     db.session.delete(asset)
     db.session.commit()
     record_audit('purge', 'asset', asset.id, user_id=current_user.id, org_id=org_id)
-    flash('Arquivo excluído permanentemente!')
+    flash('Arquivo excluído permanentemente!', 'success')
     return redirect(url_for('trash.list_trash'))


### PR DESCRIPTION
## Summary
- implement toast notifications in `base.html` and JS
- style toast and empty state components in CSS
- create reusable empty state template and placeholder image
- show the empty state on library and folder pages
- categorize flash messages in routes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68435bbdd9c483329b97f249ce7ccb1d