### PR TITLE
Improve color tokens and shadows for dark theme

### DIFF
--- a/arkiv_app/static/css/cards.css
+++ b/arkiv_app/static/css/cards.css
@@ -7,12 +7,12 @@
   padding: 1rem;
   background: var(--card-bg);
   border-radius: 8px;
-  box-shadow: 0 2px 6px rgba(0,0,0,0.08);
+  box-shadow: var(--shadow-sm);
   transition: transform 0.2s, box-shadow 0.2s;
 }
 .library-card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+  box-shadow: var(--shadow-md);
 }
 .library-thumb {
   width: 48px;
@@ -49,12 +49,12 @@
   padding: 0.75rem 1rem;
   background: var(--card-bg);
   border-radius: 6px;
-  box-shadow: 0 2px 6px rgba(0,0,0,0.05);
+  box-shadow: var(--shadow-sm);
   transition: transform 0.2s, box-shadow 0.2s;
 }
 .folder-tile:hover {
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+  box-shadow: var(--shadow-md);
 }
 .folder-badge {
   background: var(--accent);

--- a/arkiv_app/static/css/forms.css
+++ b/arkiv_app/static/css/forms.css
@@ -9,7 +9,7 @@ textarea {
   width: 100%;
   padding: 0.5rem 0.75rem;
   border-radius: 6px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
   background-color: var(--bg-color);
 }
 input:focus,
@@ -38,7 +38,7 @@ input[type="radio"]:focus {
   box-shadow: 0 0 0 3px rgba(40, 160, 176, 0.35);
 }
 .form-upload {
-  border: 2px dashed #ccc;
+  border: 2px dashed var(--border-color);
   padding: 1.5rem;
   text-align: center;
   border-radius: 6px;

--- a/arkiv_app/static/css/style.css
+++ b/arkiv_app/static/css/style.css
@@ -6,6 +6,10 @@
   --text-color: #333;
   --bg-color: #fff;
   --card-bg: #fff;
+  --border-color: #ccc;
+  --shadow-sm: 0 2px 6px rgba(0, 0, 0, 0.08);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.1);
+  --shadow-lg: 0 8px 16px rgba(0, 0, 0, 0.12);
   --font-body: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     "Helvetica Neue", Arial, sans-serif;
   --w-normal: 400;
@@ -21,6 +25,10 @@
   --text-color: #eee;
   --bg-color: #121212;
   --card-bg: #1e1e1e;
+  --border-color: #2a2a2a;
+  --shadow-sm: 0 2px 6px rgba(0, 0, 0, 0.25);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.3);
+  --shadow-lg: 0 8px 16px rgba(0, 0, 0, 0.35);
 }
 
 /* ---------- Reset / Base ---------- */
@@ -98,7 +106,7 @@ button:hover,
   justify-content: space-between;
   padding: 0 1rem;
   background: var(--card-bg);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-md);
   border-radius: 12px;
   z-index: var(--z-navbar); /* maior que modal-backdrop */
 }
@@ -124,7 +132,7 @@ button:hover,
 .global-search input {
   width: 100%;
   padding: 0.5rem 0.75rem;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
   border-radius: 4px;
 }
 
@@ -168,7 +176,7 @@ button:hover,
   margin: calc(var(--navbar-height) + 1rem) auto 1rem;
   padding: 2rem;
   border-radius: 12px;
-  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08);
+  box-shadow: var(--shadow-lg);
 }
 [data-theme="dark"] .floating-container {
   background: rgba(30, 30, 30, 0.85);
@@ -193,7 +201,7 @@ h2 {
   background: var(--card-bg);
   padding: 1.25rem;
   border-radius: 8px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+  box-shadow: var(--shadow-sm);
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
@@ -206,7 +214,7 @@ h2 {
 }
 .library-card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+  box-shadow: var(--shadow-md);
 }
 /* Cabeçalho da lib */
 .library-card__title {
@@ -277,7 +285,7 @@ nav[aria-label="breadcrumb"] .breadcrumb-item.active {
 .modal-content {
   background: var(--card-bg);
   border-radius: 12px;
-  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.12);
+  box-shadow: var(--shadow-lg);
   padding: 1.5rem;
 }
 .modal-footer {
@@ -318,12 +326,12 @@ nav[aria-label="breadcrumb"] .breadcrumb-item.active {
   background: var(--card-bg);
   border-radius: 8px;
   overflow: hidden;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+  box-shadow: var(--shadow-sm);
   transition: transform 0.2s, box-shadow 0.2s;
 }
 .asset-card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  box-shadow: var(--shadow-md);
 }
 .asset-card img {
   width: 100%;
@@ -383,7 +391,7 @@ nav[aria-label="breadcrumb"] .breadcrumb-item.active {
   border-radius: 4px;
   color: #fff;
   min-width: 200px;
-  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
 }
 .toast-success {
   background: #28a745;


### PR DESCRIPTION
## Summary
- tweak color variables and shadow tokens
- use theme variables in card, form and layout styles

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68435cfaff808332aa3051cef41a9be5