### PR TITLE
Remove invalid Jinja include syntax

### DIFF
--- a/arkiv_app/templates/asset/gallery.html
+++ b/arkiv_app/templates/asset/gallery.html
@@ -1,3 +1,4 @@
+{% import 'components/empty.html' as empty %}
 <div class="asset-gallery">
   {% for asset in assets %}
   <div class="asset-item asset-item-selectable">
@@ -18,12 +19,13 @@
     </div>
   </div>
   {% else %}
-  {% include 'components/empty.html' with
+  {{ empty.render(
       img='empty.svg',
       title='Nenhum arquivo',
       description='Use o botão acima para enviar arquivos.',
       cta_url=url_for('asset.upload_asset', folder_id=folder.id) if folder else None,
-      cta_label='Upload' %}
+      cta_label='Upload'
+  ) }}
   {% endfor %}
 </div>
 <div data-gallery-sentinel></div>

--- a/arkiv_app/templates/components/empty.html
+++ b/arkiv_app/templates/components/empty.html
@@ -1,3 +1,4 @@
+{% macro render(img=None, title='', description=None, cta_url=None, cta_label=None) %}
 <div class="empty-state">
   {% if img %}
   <img src="{{ url_for('static', filename='img/' + img) }}" alt="" class="mb-3" loading="lazy">
@@ -10,3 +11,4 @@
   <a href="{{ cta_url }}" class="btn btn-accent btn-lg">{{ cta_label }}</a>
   {% endif %}
 </div>
+{% endmacro %}

--- a/arkiv_app/templates/folder/detail.html
+++ b/arkiv_app/templates/folder/detail.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% import 'components/breadcrumb.html' as breadcrumb %}
+{% import 'components/empty.html' as empty %}
 {% block breadcrumb %}
 {{ breadcrumb.render([
   ('Bibliotecas', url_for('library.list_libraries')),
@@ -17,12 +18,13 @@
   {% set item_count = sub.assets|length + sub.children|length %}
   {% include 'folder/_tile.html' %}
   {% else %}
-  {% include 'components/empty.html' with
+  {{ empty.render(
       img='empty.svg',
       title='Esta pasta está vazia',
       description="Clique em 'Enviar Arquivo' para adicionar arquivos.",
       cta_url=url_for('asset.upload_asset', folder_id=folder.id),
-      cta_label='Enviar Arquivo' %}
+      cta_label='Enviar Arquivo'
+  ) }}
   {% endfor %}
 </div>
 {% endblock %}

--- a/arkiv_app/templates/library/detail.html
+++ b/arkiv_app/templates/library/detail.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% import 'components/breadcrumb.html' as breadcrumb %}
+{% import 'components/empty.html' as empty %}
 {% block breadcrumb %}
 {{ breadcrumb.render([
   ('Bibliotecas', url_for('library.list_libraries')),
@@ -27,12 +28,13 @@
       {% set item_count = folder.assets|length + folder.children|length %}
       {% include 'folder/_tile.html' %}
       {% else %}
-      {% include 'components/empty.html' with
+      {{ empty.render(
           img='empty.svg',
           title='Nenhuma pasta',
           description='Crie uma pasta para organizar seus arquivos.',
           cta_url=url_for('folder.create_folder') ~ '?library_id=' ~ library.id,
-          cta_label='Nova Pasta' %}
+          cta_label='Nova Pasta'
+      ) }}
       {% endfor %}
     </div>
   </div>
@@ -44,12 +46,13 @@
     {% set assets = assets %}
     {% include 'asset/gallery.html' %}
     {% else %}
-    {% include 'components/empty.html' with
+    {{ empty.render(
         img='empty.svg',
         title='Nada aqui ainda',
         description='Envie arquivos ou crie uma pasta para começar.',
         cta_url=url_for('folder.create_folder') ~ '?library_id=' ~ library.id,
-        cta_label='Nova Pasta' %}
+        cta_label='Nova Pasta'
+    ) }}
     {% endif %}
   </div>
 </div>

--- a/arkiv_app/templates/library/list.html
+++ b/arkiv_app/templates/library/list.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% import 'components/empty.html' as empty %}
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-4 flex-column flex-sm-row gap-3">
   <h1 class="mb-0">Minhas Bibliotecas</h1>
@@ -22,11 +23,12 @@
   {% endfor %}
 </div>
 {% else %}
-{% include 'components/empty.html' with
+{{ empty.render(
     img='empty.svg',
     title='Nenhuma biblioteca encontrada',
     description='Crie sua primeira biblioteca para começar a organizar seus arquivos.',
     cta_url=url_for('library.create_library'),
-    cta_label='Criar Minha Primeira Biblioteca' %}
+    cta_label='Criar Minha Primeira Biblioteca'
+) }}
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- convert `components/empty.html` into a macro
- use the macro instead of `{% include %} with` in templates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6843618ec2648332b3873866838e4d37