### PR TITLE
Fix CSP for CDN and inline scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,7 +570,7 @@ class AuditLog(db.Model):
    * Cabeçalhos de segurança adicionados por padrão:
 
      ```plaintext
-     Content-Security-Policy: default-src 'self'; img-src 'self' https:;
+    Content-Security-Policy: default-src 'self'; script-src 'self' https://cdn.jsdelivr.net 'unsafe-inline'; img-src 'self' https:;
      X-Frame-Options: DENY
      X-Content-Type-Options: nosniff
      Referrer-Policy: no-referrer-when-downgrade

--- a/arkiv_app/__init__.py
+++ b/arkiv_app/__init__.py
@@ -62,7 +62,11 @@ def create_app(config_name='development'):
 
     @app.after_request
     def _security_headers(resp):
-        resp.headers['Content-Security-Policy'] = "default-src 'self'; img-src 'self' https:;"
+        resp.headers['Content-Security-Policy'] = (
+            "default-src 'self'; "
+            "script-src 'self' https://cdn.jsdelivr.net 'unsafe-inline'; "
+            "img-src 'self' https:;"
+        )
         resp.headers['X-Frame-Options'] = 'DENY'
         resp.headers['X-Content-Type-Options'] = 'nosniff'
         resp.headers['Referrer-Policy'] = 'no-referrer-when-downgrade'


### PR DESCRIPTION
## Summary
- relax Content Security Policy to allow CDN scripts and inline handlers
- update security header docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68436aefac788332ae8f1ed573f99c19