### PR TITLE
Fix folder navigation

### DIFF
--- a/arkiv_app/folder/routes.py
+++ b/arkiv_app/folder/routes.py
@@ -4,7 +4,7 @@ from flask_login import login_required, current_user
 from ..utils import current_org_id, role_required
 
 from ..extensions import db
-from ..models import Library, Folder
+from ..models import Library, Folder, Asset
 from ..utils.audit import record_audit
 from . import folder_bp
 from .forms import FolderForm
@@ -109,9 +109,11 @@ def delete_folder(folder_id):
 def view_folder(folder_id):
     folder = Folder.query.get_or_404(folder_id)
     subfolders = Folder.query.filter_by(parent_id=folder.id).all()
+    assets = Asset.query.filter_by(folder_id=folder.id).all()
     return render_template(
         "folder/detail.html",
         folder=folder,
         subfolders=subfolders,
+        assets=assets,
         title=folder.name,
     )

--- a/arkiv_app/library/routes.py
+++ b/arkiv_app/library/routes.py
@@ -65,18 +65,10 @@ def list_libraries():
 def show_library(lib_id):
     lib = Library.query.get_or_404(lib_id)
     folders = Folder.query.filter_by(library_id=lib_id, parent_id=None).all()
-    assets = (
-        Asset.query
-        .filter_by(library_id=lib_id)
-        .order_by(Asset.created_at.desc())
-        .limit(20)
-        .all()
-    )
     return render_template(
         "library/detail.html",
         library=lib,
         folders=folders,
-        assets=assets,
         title=lib.name,
     )
 

--- a/arkiv_app/templates/folder/detail.html
+++ b/arkiv_app/templates/folder/detail.html
@@ -9,22 +9,40 @@
 ]) }}
 {% endblock %}
 {% block content %}
-<h1>{{ folder.name }}</h1>
-<a href="{{ url_for('asset.upload_asset', folder_id=folder.id) }}" class="btn btn-accent mb-2"><i class="bi bi-upload" aria-hidden="true"></i> Enviar Arquivo</a>
-<a href="{{ url_for('folder.create_folder') }}?library_id={{ folder.library_id }}&parent_id={{ folder.id }}" class="btn btn-accent mb-3"><i class="bi bi-folder-plus" aria-hidden="true"></i> Nova Subpasta</a>
-<div class="d-grid gap-2">
-  {% for sub in subfolders %}
-  {% set folder = sub %}
-  {% set item_count = sub.assets|length + sub.children|length %}
-  {% include 'folder/_tile.html' %}
-  {% else %}
-  {{ empty.render(
-      img='empty.svg',
-      title='Esta pasta está vazia',
-      description="Clique em 'Enviar Arquivo' para adicionar arquivos.",
-      cta_url=url_for('asset.upload_asset', folder_id=folder.id),
-      cta_label='Enviar Arquivo'
-  ) }}
-  {% endfor %}
+<div class="d-flex justify-content-between align-items-start flex-column flex-sm-row gap-3 mb-4">
+  <h1 class="mb-0">{{ folder.name }}</h1>
+  <div class="d-flex gap-2">
+    <a href="{{ url_for('asset.upload_asset', folder_id=folder.id) }}" class="btn btn-accent"><i class="bi bi-upload" aria-hidden="true"></i> Enviar Arquivo</a>
+    <a href="{{ url_for('folder.create_folder') }}?library_id={{ folder.library_id }}&parent_id={{ folder.id }}" class="btn btn-accent"><i class="bi bi-folder-plus" aria-hidden="true"></i> Nova Subpasta</a>
+  </div>
+</div>
+{% set root_folder = folder %}
+<div class="row">
+  <div class="col-md-3 mb-4">
+    <h6 class="mb-2">Subpastas</h6>
+    <div class="d-grid gap-2">
+      {% for sub in subfolders %}
+      {% set folder = sub %}
+      {% set item_count = sub.assets|length + sub.children|length %}
+      {% include 'folder/_tile.html' %}
+      {% else %}
+      {{ empty.render(
+          img='empty.svg',
+          title='Nenhuma subpasta',
+          description='Utilize o botão acima para criar uma pasta.',
+          cta_url=url_for('folder.create_folder') ~ '?library_id=' ~ root_folder.library_id ~ '&parent_id=' ~ root_folder.id,
+          cta_label='Nova Subpasta'
+      ) }}
+      {% endfor %}
+    </div>
+  </div>
+  <div class="col-md-9">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h6 class="mb-0">Arquivos</h6>
+    </div>
+    {% set folder = root_folder %}
+    {% set assets = assets %}
+    {% include 'asset/gallery.html' %}
+  </div>
 </div>
 {% endblock %}

--- a/arkiv_app/templates/library/detail.html
+++ b/arkiv_app/templates/library/detail.html
@@ -17,53 +17,22 @@
   </div>
   <a href="{{ url_for('library.edit_library', lib_id=library.id) }}" class="btn btn-outline-accent"><i class="bi bi-pencil"></i> Editar Biblioteca</a>
 </div>
-{% if not folders and not assets %}
-{{ empty.render(
-    img='empty.svg',
-    title='Nada aqui ainda',
-    description='Envie arquivos ou crie uma pasta para começar.',
-    cta_url=url_for('folder.create_folder') ~ '?library_id=' ~ library.id,
-    cta_label='Nova Pasta'
-) }}
-{% else %}
-<div class="row">
-  <div class="col-md-3 mb-4">
-    <div class="d-flex justify-content-between align-items-center mb-2">
-      <h6 class="mb-0">Pastas</h6>
-      <a href="{{ url_for('folder.create_folder') }}?library_id={{ library.id }}" class="btn btn-sm btn-accent" aria-label="Nova Pasta"><i class="bi bi-folder-plus"></i></a>
-    </div>
-    <div class="d-grid gap-2">
-      {% for folder in folders %}
-      {% set item_count = folder.assets|length + folder.children|length %}
-      {% include 'folder/_tile.html' %}
-      {% else %}
-      {{ empty.render(
-          img='empty.svg',
-          title='Nenhuma pasta',
-          description='Crie uma pasta para organizar seus arquivos.',
-          cta_url=url_for('folder.create_folder') ~ '?library_id=' ~ library.id,
-          cta_label='Nova Pasta'
-      ) }}
-      {% endfor %}
-    </div>
-  </div>
-  <div class="col-md-9">
-    <div class="d-flex justify-content-between align-items-center mb-3">
-      <h6 class="mb-0">Arquivos recentes</h6>
-    </div>
-    {% if assets %}
-    {% set assets = assets %}
-    {% include 'asset/gallery.html' %}
-    {% else %}
-    {{ empty.render(
-        img='empty.svg',
-        title='Nada aqui ainda',
-        description='Envie arquivos ou crie uma pasta para começar.',
-        cta_url=url_for('folder.create_folder') ~ '?library_id=' ~ library.id,
-        cta_label='Nova Pasta'
-    ) }}
-    {% endif %}
-  </div>
+<div class="d-flex justify-content-between align-items-center mb-2">
+  <h6 class="mb-0">Pastas</h6>
+  <a href="{{ url_for('folder.create_folder') }}?library_id={{ library.id }}" class="btn btn-sm btn-accent" aria-label="Nova Pasta"><i class="bi bi-folder-plus"></i></a>
 </div>
-{% endif %}
+<div class="d-grid gap-2">
+  {% for folder in folders %}
+  {% set item_count = folder.assets|length + folder.children|length %}
+  {% include 'folder/_tile.html' %}
+  {% else %}
+  {{ empty.render(
+      img='empty.svg',
+      title='Nenhuma pasta',
+      description='Crie uma pasta para organizar seus arquivos.',
+      cta_url=url_for('folder.create_folder') ~ '?library_id=' ~ library.id,
+      cta_label='Nova Pasta'
+  ) }}
+  {% endfor %}
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- simplify library detail page to only show folders
- show folders and assets when viewing a folder
- drop asset listing from library detail

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68436d9750948332a12effc23951700e