### PR TITLE
Fix missing CSRF tokens

### DIFF
--- a/arkiv_app/templates/asset/detail.html
+++ b/arkiv_app/templates/asset/detail.html
@@ -60,6 +60,7 @@
     <div class="d-grid gap-2">
       <a href="{{ url_for('asset.download_asset', asset_id=asset.id) }}" class="btn btn-accent"><i class="bi bi-download" aria-hidden="true"></i> Download</a>
       <form action="{{ url_for('asset.delete_asset', asset_id=asset.id) }}" method="post" onsubmit="return confirm('Excluir arquivo?');">
+        {{ csrf_token() }}
         <button class="btn btn-outline-danger"><i class="bi bi-trash" aria-hidden="true"></i> Excluir</button>
       </form>
     </div>

--- a/arkiv_app/templates/asset/gallery.html
+++ b/arkiv_app/templates/asset/gallery.html
@@ -12,6 +12,7 @@
         <i class="bi bi-download" aria-hidden="true"></i>
       </a>
       <form action="{{ url_for('asset.delete_asset', asset_id=asset.id) }}" method="post" onsubmit="return confirm('Excluir arquivo?');" class="d-inline">
+        {{ csrf_token() }}
         <button class="btn btn-sm btn-danger" type="submit" aria-label="Excluir">
           <i class="bi bi-trash" aria-hidden="true"></i>
         </button>

--- a/arkiv_app/templates/library/_card.html
+++ b/arkiv_app/templates/library/_card.html
@@ -19,6 +19,7 @@
       <li><a class="dropdown-item" href="{{ url_for('library.edit_library', lib_id=library.id) }}">Editar</a></li>
       <li>
         <form action="{{ url_for('library.delete_library', lib_id=library.id) }}" method="post" onsubmit="return confirm('Remover biblioteca?');">
+          {{ csrf_token() }}
           <button type="submit" class="dropdown-item text-danger">Deletar</button>
         </form>
       </li>

--- a/arkiv_app/templates/tag/list.html
+++ b/arkiv_app/templates/tag/list.html
@@ -40,6 +40,7 @@
     <div class="btn-group">
       <a href="{{ url_for('tag.edit_tag', tag_id=tag.id) }}" class="btn btn-outline-secondary btn-sm" aria-label="Editar"><i class="bi bi-pencil"></i></a>
       <form action="{{ url_for('tag.delete_tag', tag_id=tag.id) }}" method="post" class="d-inline" onsubmit="return confirm('Remover tag?');">
+        {{ csrf_token() }}
         <button type="submit" class="btn btn-outline-danger btn-sm" aria-label="Remover"><i class="bi bi-trash"></i></button>
       </form>
     </div>

--- a/arkiv_app/templates/trash/list.html
+++ b/arkiv_app/templates/trash/list.html
@@ -41,11 +41,13 @@
       </td>
       <td class="text-end">
         <form action="{{ url_for('trash.restore_asset', asset_id=a.id) }}" method="post" class="d-inline">
+          {{ csrf_token() }}
           <button class="btn btn-outline-success btn-sm" aria-label="Restaurar">
             <i class="bi bi-arrow-counterclockwise" aria-hidden="true"></i>
           </button>
         </form>
         <form action="{{ url_for('trash.purge_asset', asset_id=a.id) }}" method="post" class="d-inline" onsubmit="return confirm('Excluir permanentemente?');">
+          {{ csrf_token() }}
           <button class="btn btn-outline-danger btn-sm" aria-label="Excluir definitivamente">
             <i class="bi bi-trash" aria-hidden="true"></i>
           </button>


### PR DESCRIPTION
## Summary
- include CSRF tokens on delete forms

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68436f664c708332b5bc6fe4945401c1