### PR TITLE
Fix dropdown styling and reset list defaults

### DIFF
--- a/arkiv_app/static/css/style.css
+++ b/arkiv_app/static/css/style.css
@@ -292,20 +292,24 @@ h2 {
 }
 
 /* ---------- Listas padrão ---------- */
-ul {
+ul,
+ol {
   list-style: none;
-  padding-left: 1rem;
+  padding-left: 0;
+  margin: 0;
 }
-ul li {
-  position: relative;
-  padding-left: 0.75rem;
+
+ul li,
+ol li {
   margin: 0.25rem 0;
+  padding-left: 0;
 }
-ul li::before {
-  content: "•";
-  position: absolute;
-  left: 0;
-  color: var(--accent);
+
+/* Remove bullets from Bootstrap components */
+.dropdown-menu li::before,
+.list-group li::before,
+.list-unstyled li::before {
+  content: none;
 }
 
 nav[aria-label="breadcrumb"] {


### PR DESCRIPTION
## Summary
- clean default list styles so Bootstrap menus work
- ensure dropdown menu bullets are removed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68479318210c8332a2bb883dc27afbe0