### PR TITLE
Add notice, poll and ticket modules

### DIFF
--- a/arkiv_app/__init__.py
+++ b/arkiv_app/__init__.py
@@ -44,6 +44,9 @@ def create_app(config_name='development'):
     from .admin import admin_bp
     from .organization import organization_bp
     from .trash import trash_bp
+    from .notice import notice_bp
+    from .poll import poll_bp
+    from .ticket import ticket_bp
 
     app.register_blueprint(main_bp)
     app.register_blueprint(api_bp)
@@ -58,6 +61,9 @@ def create_app(config_name='development'):
     app.register_blueprint(admin_bp)
     app.register_blueprint(organization_bp)
     app.register_blueprint(trash_bp)
+    app.register_blueprint(notice_bp)
+    app.register_blueprint(poll_bp)
+    app.register_blueprint(ticket_bp)
     csrf.exempt(api_bp)
 
     @app.after_request

--- a/arkiv_app/models.py
+++ b/arkiv_app/models.py
@@ -192,3 +192,69 @@ class AuditLog(db.Model):
             'sqlite_autoincrement': True,
         },
     )
+
+
+class Notice(db.Model):
+    __tablename__ = "notice"
+    id = db.Column(db.Integer, primary_key=True)
+    org_id = db.Column(db.Integer, db.ForeignKey("organization.id"), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    title = db.Column(db.String(200), nullable=False)
+    body = db.Column(db.Text, nullable=False)
+    category = db.Column(db.String(50))
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    expires_at = db.Column(db.DateTime)
+    is_pinned = db.Column(db.Boolean, default=False)
+
+    organization = db.relationship("Organization")
+    author = db.relationship("User")
+
+
+class Poll(db.Model):
+    __tablename__ = "poll"
+    id = db.Column(db.Integer, primary_key=True)
+    org_id = db.Column(db.Integer, db.ForeignKey("organization.id"), nullable=False)
+    creator_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    question = db.Column(db.String(255), nullable=False)
+    closes_at = db.Column(db.DateTime)
+    is_closed = db.Column(db.Boolean, default=False)
+
+    organization = db.relationship("Organization")
+    creator = db.relationship("User")
+    options = db.relationship("PollOption", back_populates="poll")
+
+
+class PollOption(db.Model):
+    __tablename__ = "poll_option"
+    id = db.Column(db.Integer, primary_key=True)
+    poll_id = db.Column(db.Integer, db.ForeignKey("poll.id"), nullable=False)
+    text = db.Column(db.String(255), nullable=False)
+
+    poll = db.relationship("Poll", back_populates="options")
+    votes = db.relationship("PollVote", back_populates="option")
+
+
+class PollVote(db.Model):
+    __tablename__ = "poll_vote"
+    id = db.Column(db.Integer, primary_key=True)
+    option_id = db.Column(db.Integer, db.ForeignKey("poll_option.id"), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    option = db.relationship("PollOption", back_populates="votes")
+    voter = db.relationship("User")
+
+
+class Ticket(db.Model):
+    __tablename__ = "ticket"
+    id = db.Column(db.Integer, primary_key=True)
+    org_id = db.Column(db.Integer, db.ForeignKey("organization.id"), nullable=False)
+    creator_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    title = db.Column(db.String(200), nullable=False)
+    description = db.Column(db.Text, nullable=False)
+    status = db.Column(db.String(20), default="open")
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, onupdate=datetime.utcnow)
+
+    organization = db.relationship("Organization")
+    creator = db.relationship("User")

--- a/arkiv_app/notice/__init__.py
+++ b/arkiv_app/notice/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+notice_bp = Blueprint('notice', __name__)
+
+from . import routes  # noqa

--- a/arkiv_app/notice/forms.py
+++ b/arkiv_app/notice/forms.py
@@ -1,0 +1,10 @@
+from flask_wtf import FlaskForm
+from wtforms import StringField, TextAreaField, SubmitField
+from wtforms.validators import DataRequired
+
+
+class NoticeForm(FlaskForm):
+    title = StringField('Título', validators=[DataRequired()])
+    body = TextAreaField('Conteúdo', validators=[DataRequired()])
+    category = StringField('Categoria')
+    submit = SubmitField('Salvar')

--- a/arkiv_app/notice/routes.py
+++ b/arkiv_app/notice/routes.py
@@ -1,0 +1,38 @@
+from flask import render_template, redirect, url_for, flash, request
+from flask_login import login_required, current_user
+
+from ..extensions import db
+from ..models import Notice
+from ..utils.audit import record_audit
+from ..utils import current_org_id
+from . import notice_bp
+from .forms import NoticeForm
+
+
+@notice_bp.route('/notices')
+@login_required
+def list_notices():
+    org_id = current_org_id()
+    notices = Notice.query.filter_by(org_id=org_id).order_by(Notice.created_at.desc()).all()
+    return render_template('notice/list.html', notices=notices, title='Mural')
+
+
+@notice_bp.route('/notices/create', methods=['GET', 'POST'])
+@login_required
+def create_notice():
+    form = NoticeForm()
+    if form.validate_on_submit():
+        org_id = current_org_id()
+        notice = Notice(
+            org_id=org_id,
+            user_id=current_user.id,
+            title=form.title.data,
+            body=form.body.data,
+            category=form.category.data,
+        )
+        db.session.add(notice)
+        db.session.commit()
+        record_audit('create', 'notice', notice.id, user_id=current_user.id, org_id=org_id)
+        flash('Aviso criado', 'success')
+        return redirect(url_for('notice.list_notices'))
+    return render_template('notice/form.html', form=form, title='Novo Aviso')

--- a/arkiv_app/poll/__init__.py
+++ b/arkiv_app/poll/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+poll_bp = Blueprint('poll', __name__)
+
+from . import routes  # noqa

--- a/arkiv_app/poll/forms.py
+++ b/arkiv_app/poll/forms.py
@@ -1,0 +1,10 @@
+from flask_wtf import FlaskForm
+from wtforms import StringField, TextAreaField, DateTimeField, SubmitField, FieldList
+from wtforms.validators import DataRequired
+
+
+class PollForm(FlaskForm):
+    question = StringField('Pergunta', validators=[DataRequired()])
+    closes_at = DateTimeField('Encerra em', format='%Y-%m-%d %H:%M', validators=[])
+    options = FieldList(StringField('Opção', validators=[DataRequired()]), min_entries=2)
+    submit = SubmitField('Salvar')

--- a/arkiv_app/poll/routes.py
+++ b/arkiv_app/poll/routes.py
@@ -1,0 +1,55 @@
+from flask import render_template, redirect, url_for, flash, request
+from flask_login import login_required, current_user
+
+from ..extensions import db
+from ..models import Poll, PollOption, PollVote
+from ..utils.audit import record_audit
+from ..utils import current_org_id
+from . import poll_bp
+from .forms import PollForm
+
+
+@poll_bp.route('/polls')
+@login_required
+def list_polls():
+    org_id = current_org_id()
+    polls = Poll.query.filter_by(org_id=org_id).order_by(Poll.created_at.desc()).all()
+    return render_template('poll/list.html', polls=polls, title='Enquetes')
+
+
+@poll_bp.route('/polls/create', methods=['GET', 'POST'])
+@login_required
+def create_poll():
+    form = PollForm()
+    if form.validate_on_submit():
+        org_id = current_org_id()
+        poll = Poll(
+            org_id=org_id,
+            creator_id=current_user.id,
+            question=form.question.data,
+            closes_at=form.closes_at.data,
+        )
+        db.session.add(poll)
+        db.session.flush()
+        for opt_text in form.options.data:
+            if opt_text:
+                db.session.add(PollOption(poll_id=poll.id, text=opt_text))
+        db.session.commit()
+        record_audit('create', 'poll', poll.id, user_id=current_user.id, org_id=org_id)
+        flash('Enquete criada', 'success')
+        return redirect(url_for('poll.list_polls'))
+    return render_template('poll/form.html', form=form, title='Nova Enquete')
+
+
+@poll_bp.route('/polls/<int:poll_id>/vote/<int:option_id>', methods=['POST'])
+@login_required
+def vote(poll_id, option_id):
+    poll = Poll.query.get_or_404(poll_id)
+    option = PollOption.query.get_or_404(option_id)
+    existing = PollVote.query.filter_by(option_id=option_id, user_id=current_user.id).first()
+    if not existing:
+        vote = PollVote(option_id=option.id, user_id=current_user.id)
+        db.session.add(vote)
+        db.session.commit()
+        flash('Voto registrado', 'success')
+    return redirect(url_for('poll.list_polls'))

--- a/arkiv_app/templates/notice/form.html
+++ b/arkiv_app/templates/notice/form.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Novo Aviso</h1>
+<form method="post">
+  {{ form.hidden_tag() }}
+  <div class="mb-3">{{ form.title.label }} {{ form.title(class='form-control') }}</div>
+  <div class="mb-3">{{ form.category.label }} {{ form.category(class='form-control') }}</div>
+  <div class="mb-3">{{ form.body.label }} {{ form.body(class='form-control') }}</div>
+  {{ form.submit(class='btn btn-primary') }}
+</form>
+{% endblock %}

--- a/arkiv_app/templates/notice/list.html
+++ b/arkiv_app/templates/notice/list.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Mural</h1>
+<a href="{{ url_for('notice.create_notice') }}" class="btn btn-accent mb-3">Novo Aviso</a>
+<ul class="list-group">
+  {% for n in notices %}
+  <li class="list-group-item">
+    <strong>{{ n.title }}</strong> - {{ n.category }}
+    <div>{{ n.body }}</div>
+  </li>
+  {% else %}
+  <li class="list-group-item">Nenhum aviso.</li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/arkiv_app/templates/poll/form.html
+++ b/arkiv_app/templates/poll/form.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Nova Enquete</h1>
+<form method="post">
+  {{ form.hidden_tag() }}
+  <div class="mb-3">{{ form.question.label }} {{ form.question(class='form-control') }}</div>
+  <div class="mb-3">{{ form.closes_at.label }} {{ form.closes_at(class='form-control') }}</div>
+  {% for opt in form.options %}
+  <div class="mb-3">{{ opt.label }} {{ opt(class='form-control') }}</div>
+  {% endfor %}
+  {{ form.submit(class='btn btn-primary') }}
+</form>
+{% endblock %}

--- a/arkiv_app/templates/poll/list.html
+++ b/arkiv_app/templates/poll/list.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Enquetes</h1>
+<a href="{{ url_for('poll.create_poll') }}" class="btn btn-accent mb-3">Nova Enquete</a>
+<ul class="list-group">
+  {% for p in polls %}
+  <li class="list-group-item">
+    <strong>{{ p.question }}</strong>
+    <form action="{{ url_for('poll.vote', poll_id=p.id, option_id=p.options[0].id) }}" method="post" class="mt-2">
+      {% for opt in p.options %}
+      <button name="option" value="{{ opt.id }}" formaction="{{ url_for('poll.vote', poll_id=p.id, option_id=opt.id) }}" class="btn btn-sm btn-secondary me-2">{{ opt.text }}</button>
+      {% endfor %}
+    </form>
+  </li>
+  {% else %}
+  <li class="list-group-item">Nenhuma enquete.</li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/arkiv_app/templates/ticket/form.html
+++ b/arkiv_app/templates/ticket/form.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Novo Chamado</h1>
+<form method="post">
+  {{ form.hidden_tag() }}
+  <div class="mb-3">{{ form.title.label }} {{ form.title(class='form-control') }}</div>
+  <div class="mb-3">{{ form.description.label }} {{ form.description(class='form-control') }}</div>
+  {{ form.submit(class='btn btn-primary') }}
+</form>
+{% endblock %}

--- a/arkiv_app/templates/ticket/list.html
+++ b/arkiv_app/templates/ticket/list.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Chamados</h1>
+<a href="{{ url_for('ticket.create_ticket') }}" class="btn btn-accent mb-3">Novo Chamado</a>
+<ul class="list-group">
+  {% for t in tickets %}
+  <li class="list-group-item">
+    <strong>{{ t.title }}</strong> - {{ t.status }}
+    <div>{{ t.description }}</div>
+  </li>
+  {% else %}
+  <li class="list-group-item">Nenhum chamado.</li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/arkiv_app/ticket/__init__.py
+++ b/arkiv_app/ticket/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+ticket_bp = Blueprint('ticket', __name__)
+
+from . import routes  # noqa

--- a/arkiv_app/ticket/forms.py
+++ b/arkiv_app/ticket/forms.py
@@ -1,0 +1,9 @@
+from flask_wtf import FlaskForm
+from wtforms import StringField, TextAreaField, SubmitField
+from wtforms.validators import DataRequired
+
+
+class TicketForm(FlaskForm):
+    title = StringField('Título', validators=[DataRequired()])
+    description = TextAreaField('Descrição', validators=[DataRequired()])
+    submit = SubmitField('Salvar')

--- a/arkiv_app/ticket/routes.py
+++ b/arkiv_app/ticket/routes.py
@@ -1,0 +1,37 @@
+from flask import render_template, redirect, url_for, flash
+from flask_login import login_required, current_user
+
+from ..extensions import db
+from ..models import Ticket
+from ..utils.audit import record_audit
+from ..utils import current_org_id
+from . import ticket_bp
+from .forms import TicketForm
+
+
+@ticket_bp.route('/tickets')
+@login_required
+def list_tickets():
+    org_id = current_org_id()
+    tickets = Ticket.query.filter_by(org_id=org_id).order_by(Ticket.created_at.desc()).all()
+    return render_template('ticket/list.html', tickets=tickets, title='Chamados')
+
+
+@ticket_bp.route('/tickets/create', methods=['GET', 'POST'])
+@login_required
+def create_ticket():
+    form = TicketForm()
+    if form.validate_on_submit():
+        org_id = current_org_id()
+        ticket = Ticket(
+            org_id=org_id,
+            creator_id=current_user.id,
+            title=form.title.data,
+            description=form.description.data,
+        )
+        db.session.add(ticket)
+        db.session.commit()
+        record_audit('create', 'ticket', ticket.id, user_id=current_user.id, org_id=org_id)
+        flash('Chamado criado', 'success')
+        return redirect(url_for('ticket.list_tickets'))
+    return render_template('ticket/form.html', form=form, title='Novo Chamado')

--- a/tests/test_notice.py
+++ b/tests/test_notice.py
@@ -1,0 +1,14 @@
+from arkiv_app.extensions import db
+from arkiv_app.models import Notice
+
+
+def test_notice_list_view(client, app):
+    client.post('/login', data={'email': 'test@example.com', 'password': 'test'}, follow_redirects=True)
+    with app.app_context():
+        notice = Notice(org_id=1, user_id=1, title='Aviso', body='Corpo')
+        db.session.add(notice)
+        db.session.commit()
+        notice_id = notice.id
+    res = client.get('/notices')
+    assert res.status_code == 200
+    assert b'Aviso' in res.data

--- a/tests/test_poll.py
+++ b/tests/test_poll.py
@@ -1,0 +1,17 @@
+from arkiv_app.extensions import db
+from arkiv_app.models import Poll, PollOption
+
+
+def test_poll_create_and_vote(client, app):
+    client.post('/login', data={'email': 'test@example.com', 'password': 'test'}, follow_redirects=True)
+    with app.app_context():
+        poll = Poll(org_id=1, creator_id=1, question='Pergunta')
+        db.session.add(poll)
+        db.session.flush()
+        opt = PollOption(poll_id=poll.id, text='Op1')
+        db.session.add(opt)
+        db.session.commit()
+        poll_id = poll.id
+        option_id = opt.id
+    res = client.post(f'/polls/{poll_id}/vote/{option_id}', follow_redirects=True)
+    assert res.status_code == 200

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -1,0 +1,13 @@
+from arkiv_app.extensions import db
+from arkiv_app.models import Ticket
+
+
+def test_ticket_list_view(client, app):
+    client.post('/login', data={'email': 'test@example.com', 'password': 'test'}, follow_redirects=True)
+    with app.app_context():
+        ticket = Ticket(org_id=1, creator_id=1, title='Chamado', description='Desc')
+        db.session.add(ticket)
+        db.session.commit()
+    res = client.get('/tickets')
+    assert res.status_code == 200
+    assert b'Chamado' in res.data


### PR DESCRIPTION
## Summary
- implement Notice, Poll and Ticket models
- add blueprints for notice board, polls and tickets
- register new blueprints
- create minimal templates
- add tests for new features

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6854435c75648332b845fc031ad13688